### PR TITLE
Makes MacroSupport more generic.

### DIFF
--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/Maestro.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/Maestro.scala
@@ -18,7 +18,7 @@ import com.twitter.scrooge.ThriftStruct
 
 import com.twitter.scalding.{Args, Job, CascadeJob}
 
-import au.com.cba.omnia.maestro.macros.MacroSupport
+import au.com.cba.omnia.maestro.macros.LegacyMacroSupport
 
 import au.com.cba.omnia.maestro.core.task._
 import au.com.cba.omnia.maestro.core.args.Config
@@ -29,7 +29,7 @@ import au.com.cba.omnia.maestro.core.time.OldTimeSourceFunctions
   * Parent class for a more complex maestro job that needs to use cascades. For example, to run hive
   * queries.
   */
-abstract class MaestroCascade[A <: ThriftStruct](args: Args) extends CascadeJob(args) with MacroSupport[A] {
+abstract class MaestroCascade[A <: ThriftStruct](args: Args) extends CascadeJob(args) with LegacyMacroSupport[A] {
   /** Don't run any cascading jobs if the job list is empty. */
   override def run =
     if (jobs.isEmpty) true
@@ -46,7 +46,7 @@ abstract class MaestroCascade[A <: ThriftStruct](args: Args) extends CascadeJob(
 }
 
 /** Parent class for a simple maestro job that does not need to use cascades or run hive queries.*/
-abstract class Maestro[A <: ThriftStruct](args: Args) extends Job(args) with MacroSupport[A]
+abstract class Maestro[A <: ThriftStruct](args: Args) extends Job(args) with LegacyMacroSupport[A]
 
 object Maestro
     extends Load

--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/Maestro.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/Maestro.scala
@@ -26,4 +26,5 @@ object Maestro
   with QueryExecution
   with SqoopExecution
   with ExecutionOps
+  with MacroSupport
 

--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/MaestroJob.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/MaestroJob.scala
@@ -29,4 +29,4 @@ import au.com.cba.omnia.maestro.core.exec.MaestroExecutionMain
   * The job will exit with an error code describing the status of the program.
   * The software running this program can then take the appropriate action.
   */
-trait MaestroJob[A <: ThriftStruct] extends MaestroExecutionMain with MacroSupport[A]
+trait MaestroJob[A <: ThriftStruct] extends MaestroExecutionMain

--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/package.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/package.scala
@@ -17,7 +17,7 @@ package au.com.cba.omnia.maestro.api
 import com.twitter.scrooge.ThriftStruct
 
 package object exec {
-  type MacroSupport[A <: ThriftStruct] = au.com.cba.omnia.maestro.macros.MacroSupport[A]
+  type MacroSupport    = au.com.cba.omnia.maestro.macros.MacroSupport
 
   type JobStatus       = au.com.cba.omnia.maestro.core.exec.JobStatus
   type JobFinished     = au.com.cba.omnia.maestro.core.exec.JobFinished.type

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerExecution.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerExecution.scala
@@ -18,12 +18,12 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
 
 import com.twitter.scalding.{Config, Execution}
 
-import au.com.cba.omnia.maestro.api.exec._
-import au.com.cba.omnia.maestro.api.exec.Maestro._
+import au.com.cba.omnia.maestro.api.exec._, Maestro._
 import au.com.cba.omnia.maestro.example.thrift.{Account, Customer}
 
 /** Configuration for a customer execution example */
-case class CustomerConfig(config: Config) extends MacroSupport[Customer] {
+case class CustomerConfig(config: Config) {
+
   val maestro   = MaestroConfig(
     conf        = config,
     source      = "customer",
@@ -31,15 +31,15 @@ case class CustomerConfig(config: Config) extends MacroSupport[Customer] {
     tablename   = "customer"
   )
   val upload    = maestro.upload()
-  val load      = maestro.load(
+  val load      = maestro.load[Customer](
     none        = "null"
   )
   val dateTable = maestro.partitionedHiveTable[Customer, (String, String, String)](
-    partition   = Partition.byDate(Fields.EffectiveDate),
+    partition   = Partition.byDate(Fields[Customer].EffectiveDate),
     tablename   = "by_date"
   )
   val catTable  = maestro.partitionedHiveTable[Customer, String](
-    partition   = Partition.byField(Fields.Cat),
+    partition   = Partition.byField(Fields[Customer].Cat),
     tablename   = "by_cat"
   )
   val writeToCatTableQuery = QueryConfig(
@@ -51,7 +51,7 @@ case class CustomerConfig(config: Config) extends MacroSupport[Customer] {
 }
 
 /** Customer execution example */
-object CustomerExecution extends MacroSupport[Customer] {
+object CustomerExecution {
 
   /** Create an example customer execution */
   def execute: Execution[(LoadSuccess, Long)] = for {

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportExecution.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportExecution.scala
@@ -20,12 +20,11 @@ import com.twitter.scalding.{Config, Execution}
 
 import au.com.cba.omnia.parlour.SqoopSyntax.ParlourExportDsl
 
-import au.com.cba.omnia.maestro.api.exec._
-import au.com.cba.omnia.maestro.api.exec.Maestro._
+import au.com.cba.omnia.maestro.api.exec._, Maestro._
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
 /** Configuration for `CustomerSqoopExportExecution` */
-case class CustomerExportConfig(config: Config) extends MacroSupport[Customer] {
+case class CustomerExportConfig(config: Config) {
   val maestro = MaestroConfig(
     conf         = config,
     source       = "customer",
@@ -40,7 +39,7 @@ case class CustomerExportConfig(config: Config) extends MacroSupport[Customer] {
 }
 
 /** Customer execution, exporting data to a database via Sqoop */
-object CustomerSqoopExportExecution extends MacroSupport[Customer] {
+object CustomerSqoopExportExecution {
   def execute: Execution[Unit] = {
     for {
       conf <- Execution.getConfig.map(CustomerExportConfig(_))

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecution.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecution.scala
@@ -22,12 +22,11 @@ import com.twitter.scalding.{Config, Execution}
 
 import au.com.cba.omnia.parlour.ParlourImportOptions
 
-import au.com.cba.omnia.maestro.api.exec._
-import au.com.cba.omnia.maestro.api.exec.Maestro._
+import au.com.cba.omnia.maestro.api.exec._, Maestro._
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
 /** Configuration for `CustomerSqoopImportExecution` */
-case class CustomerImportConfig(config: Config) extends MacroSupport[Customer] {
+case class CustomerImportConfig(config: Config) {
   val maestro     = MaestroConfig(
     conf          = config,
     source        = "sales",
@@ -37,17 +36,17 @@ case class CustomerImportConfig(config: Config) extends MacroSupport[Customer] {
   val sqoopImport  = maestro.sqoopImport(
     initialOptions = Some(ParlourImportDsl().splitBy("id"))
   )
-  val load        = maestro.load(
+  val load        = maestro.load[Customer](
     none          = "null"
   )
   val catTable    = maestro.partitionedHiveTable[Customer, String](
-    partition     = Partition.byField(Fields.Cat),
+    partition     = Partition.byField(Fields[Customer].Cat),
     tablename     = "by_cat"
   )
 }
 
 /** Example customer execution, importing data via Sqoop */
-object CustomerSqoopImportExecution extends MacroSupport[Customer] {
+object CustomerSqoopImportExecution {
   /** Create an example customer sqoop import execution */
   def execute: Execution[CustomerImportStatus] = for {
     conf               <- Execution.getConfig.map(CustomerImportConfig(_))

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerExecutionSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerExecutionSpec.scala
@@ -20,7 +20,7 @@ import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.test.ParquetThermometerRecordReader
 
-import au.com.cba.omnia.maestro.api.exec._
+import au.com.cba.omnia.maestro.api.exec._, Maestro._
 
 import au.com.cba.omnia.maestro.test.Records
 
@@ -29,8 +29,7 @@ import au.com.cba.omnia.maestro.example.thrift.Customer
 object CustomerExecutionSpec
   extends ThermometerSpec
   with Records
-  with HiveSupport
-  with MacroSupport[Customer] { def is = s2"""
+  with HiveSupport { def is = s2"""
 
 Customer Execution
 ==================

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecutionSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecutionSpec.scala
@@ -24,7 +24,7 @@ import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.test.ParquetThermometerRecordReader
 
-import au.com.cba.omnia.maestro.api.exec._
+import au.com.cba.omnia.maestro.api.exec._, Maestro._
 
 import au.com.cba.omnia.maestro.test.Records
 
@@ -33,8 +33,7 @@ import au.com.cba.omnia.maestro.example.thrift.Customer
 object CustomerSqoopImportExecutionSpec
   extends ThermometerSpec
   with Records
-  with HiveSupport
-  with MacroSupport[Customer] { def is = s2"""
+  with HiveSupport { def is = s2"""
 
 CustomerSqoopImportExecution test
 =================================

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Macros.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Macros.scala
@@ -32,6 +32,7 @@ object Macros {
   def mkTag[A <: ThriftStruct]: Tag[A] =
     macro TagMacro.impl[A]
 
+  @deprecated("Duplicate of mkFields", "1.14.0")
   def getFields[A <: ThriftStruct]: Any =
     macro FieldsMacro.impl[A]
 
@@ -57,7 +58,35 @@ object Macros {
   ): Transform[A, B] = macro TransformMacro.impl[A, B]
 }
 
-trait MacroSupport[A <: ThriftStruct] {
+/** Provides implicit Decode, Tag, etc. views for a ThriftStruct. */
+trait MacroSupport {
+  /** Macro generated Decode for a Thrift struct. */
+  implicit def DerivedDecode[A <: ThriftStruct]: Decode[A] =
+    macro DecodeMacro.impl[A]
+
+  /** Macro generated Encode for a Thrift struct. */
+  implicit def DerivedEncode[A <: ThriftStruct]: Encode[A] =
+    macro EncodeMacro.impl[A]
+
+  /** Macro generated Tag for a Thrift struct. */
+  implicit def DerivedTag[A <: ThriftStruct]: Tag[A] =
+    macro TagMacro.impl[A]
+
+  /** Macro generated structural type containing the fields for a Thrift struct. */
+  // NOTE: This isn't really any, it is a structural type containing all the fields.
+  def Fields[A <: ThriftStruct]: Any =
+    macro FieldsMacro.impl[A]
+}
+
+/** Provides implicit Decode, Tag, etc. views for a ThriftStruct. */
+object MacroSupport extends MacroSupport
+
+
+/**
+  * MacroSupport to still support the old MaestroCascade.
+  * This is now superseded by the newer MacroSupport.
+  */
+trait LegacyMacroSupport[A <: ThriftStruct] {
   implicit def DerivedDecode: Decode[A] =
     macro DecodeMacro.impl[A]
 


### PR DESCRIPTION
Creates an old version of MacroSupport for the pre execution code (LegacyMacroSupport).

Then creates a new version of Macro support that provides implicit views for thrift structs. The old version forced the whole trait to be tied to a specific thrift struct this instead just provides implicit methods for any thrift struct. Instead of being tied to MaestroJob this is now also provided as part of `exec.Maestro._`.