### PR TITLE
Hive monad

### DIFF
--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/Maestro.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/Maestro.scala
@@ -14,6 +14,8 @@
 
 package au.com.cba.omnia.maestro.api.exec
 
+import au.com.cba.omnia.permafrost.hdfs.HdfsStrings
+
 import au.com.cba.omnia.maestro.core.exec.{LoadExecution, SqoopExecution, UploadExecution, ViewExecution, QueryExecution}
 import au.com.cba.omnia.maestro.core.scalding.ExecutionOps
 
@@ -27,4 +29,5 @@ object Maestro
   with SqoopExecution
   with ExecutionOps
   with MacroSupport
+  with HdfsStrings
 

--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/package.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/exec/package.scala
@@ -83,6 +83,12 @@ package object exec {
   type QueryConfig     = au.com.cba.omnia.maestro.core.exec.QueryConfig
   val  QueryConfig     = au.com.cba.omnia.maestro.core.exec.QueryConfig
 
+  type Hdfs[A]         = au.com.cba.omnia.permafrost.hdfs.Hdfs[A]
+  val  Hdfs            = au.com.cba.omnia.permafrost.hdfs.Hdfs
+
+  type Hive[A]         = au.com.cba.omnia.ebenezer.scrooge.hive.Hive[A]
+  val  Hive            = au.com.cba.omnia.ebenezer.scrooge.hive.Hive
+
   type ParlourImportDsl         = au.com.cba.omnia.parlour.SqoopSyntax.ParlourImportDsl
   type ParlourExportDsl         = au.com.cba.omnia.parlour.SqoopSyntax.ParlourExportDsl
   type TeradataParlourImportDsl = au.com.cba.omnia.parlour.SqoopSyntax.TeradataParlourImportDsl

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/exec/QueryExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/exec/QueryExecution.scala
@@ -31,6 +31,7 @@ import au.com.cba.omnia.maestro.core.hive.HiveTable
   * @param queries:  The hive queries to run
   * @param settings: Hive settings. Empty by default.
   */
+@deprecated("Use the query/queries method in Hive instead", "1.15")
 case class QueryConfig(
   name: String,
   queries: Seq[String],
@@ -38,8 +39,10 @@ case class QueryConfig(
 )
 
 /** Factory functions for query configs */
+@deprecated("Use the query/queries method in Hive instead", "1.15")
 object QueryConfig {
   /** QueryConfig with empty hive settings */
+  @deprecated("Use the query/queries method in Hive instead", "1.15")
   def apply(
     name: String,
     queries: String*
@@ -47,6 +50,7 @@ object QueryConfig {
     QueryConfig(name, queries)
 
   /** QueryConfig */
+  @deprecated("Use the query/queries method in Hive instead", "1.15")
   def apply(
     name: String,
     settings: Map[ConfVars, String],
@@ -62,6 +66,7 @@ trait QueryExecution {
     *
     * When specified, the output value is used to create the target table before the job starts
     */
+  @deprecated("Use the query/queries method in Hive instead", "1.15")
   def hiveQuery(config: QueryConfig) : Execution[Unit] =
     HiveExecution.query(config.name, config.settings, config.queries: _*)
  }

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/exec/UploadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/exec/UploadExecution.scala
@@ -21,7 +21,9 @@ import scalaz.\&/.{This, That, Both}
 
 import com.twitter.scalding.Execution
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Hdfs, Ok, Result}
+import au.com.cba.omnia.omnitool.{Error, Ok, Result}
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 import au.com.cba.omnia.maestro.core.scalding.ConfHelper
 import au.com.cba.omnia.maestro.core.task.Upload

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
@@ -20,7 +20,9 @@ import scalaz.\&/.{This, That, Both}
 
 import com.twitter.scalding.{Config, Execution}
 
-import au.com.cba.omnia.permafrost.hdfs.{Hdfs, Ok, Error}
+import au.com.cba.omnia.omnitool.{Error, Ok, Result}
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 /** Pimps an Execution instance. */
 case class RichExecution[A](execution: Execution[A]) {

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/Upload.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/Upload.scala
@@ -25,7 +25,9 @@ import org.apache.log4j.Logger
 
 import scalaz._, Scalaz._, scalaz.\&/.{This, That, Both}
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Hdfs, Ok, Result}
+import au.com.cba.omnia.omnitool.{Error, Ok, Result}
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 import au.com.cba.omnia.maestro.core.upload._
 

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/Upload.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/Upload.scala
@@ -23,9 +23,9 @@ import org.apache.hadoop.conf.Configuration
 
 import org.apache.log4j.Logger
 
-import scalaz._, Scalaz._, scalaz.\&/.{This, That, Both}
+import scalaz._, Scalaz._
 
-import au.com.cba.omnia.omnitool.{Error, Ok, Result}
+import au.com.cba.omnia.omnitool.Result
 
 import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
@@ -138,12 +138,12 @@ trait Upload {
     ).safe.run(conf)
 
     val args = s"$source/$domain/$tableName"
-    result match {
-      case Ok(_)                 => logger.info(s"Upload ended for $args")
-      case Error(This(msg))      => logger.error(s"Upload failed for $args: $msg")
-      case Error(That(exn))      => logger.error(s"Upload failed for $args", exn)
-      case Error(Both(msg, exn)) => logger.error(s"Upload failed for $args: $msg", exn)
-    }
+    result.foldAll(
+      _         => logger.info(s"Upload ended for $args"),
+      msg       => logger.error(s"Upload failed for $args: $msg"),
+      ex        => logger.error(s"Upload failed for $args", ex),
+      (msg, ex) => logger.error(s"Upload failed for $args: $msg", ex)
+    )
 
     result
   }
@@ -191,12 +191,12 @@ trait Upload {
         localArchivePath, hdfsArchivePath, hdfsLandingPath,
         controlPattern).safe.run(conf)
 
-    result match {
-      case Ok(_)                 => logger.info(s"Custom upload ended from $localIngestPath")
-      case Error(This(msg))      => logger.error(s"Custom upload failed from $localIngestPath: $msg")
-      case Error(That(exn))      => logger.error(s"Custom upload failed from $localIngestPath", exn)
-      case Error(Both(msg, exn)) => logger.error(s"Custom upload failed from $localIngestPath: $msg", exn)
-    }
+    result.foldAll(
+      _         => logger.info(s"Custom upload ended from $localIngestPath"),
+      msg       => logger.error(s"Custom upload failed from $localIngestPath: $msg"),
+      ex        => logger.error(s"Custom upload failed from $localIngestPath", ex),
+      (msg, ex) => logger.error(s"Custom upload failed from $localIngestPath: $msg", ex)
+    )
 
     result
   }

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Input.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Input.scala
@@ -23,8 +23,6 @@ import scalaz._, Scalaz._
 
 import au.com.cba.omnia.omnitool.Result
 
-import au.com.cba.omnia.permafrost.hdfs.Hdfs
-
 /** A file existing in the source directory */
 sealed trait Input
 

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Input.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Input.scala
@@ -21,7 +21,9 @@ import scala.util.matching.Regex
 
 import scalaz._, Scalaz._
 
-import au.com.cba.omnia.permafrost.hdfs.{Hdfs, Result}
+import au.com.cba.omnia.omnitool.Result
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 /** A file existing in the source directory */
 sealed trait Input

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Push.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Push.scala
@@ -23,9 +23,10 @@ import org.apache.hadoop.fs.Path
 
 import com.google.common.io.Files
 
-import au.com.cba.omnia.permafrost.hdfs.{Hdfs, Result}
-
+import au.com.cba.omnia.omnitool.Result
 import au.com.cba.omnia.omnitool.file.ops.Temp
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 /** File copied to HDFS */
 case class Copied(source: File, dest: Path)

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Push.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/upload/Push.scala
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.Path
 
 import com.google.common.io.Files
 
-import au.com.cba.omnia.omnitool.Result
 import au.com.cba.omnia.omnitool.file.ops.Temp
 
 import au.com.cba.omnia.permafrost.hdfs.Hdfs
@@ -95,12 +94,10 @@ object Push {
 
   /** Move file to another directory. Convienient to run in a Hdfs operation. */
   def moveToDir(file: File, destDir: File): Hdfs[Unit] =
-    Hdfs.result(
       for {
-        _ <- Result.guard(destDir.isDirectory || destDir.mkdirs, s"$destDir could not be created")
-        _ <- Result.ok[Unit](Files.move(file, new File(destDir, file.getName)))
+        _ <- Hdfs.guard(destDir.isDirectory || destDir.mkdirs, s"$destDir could not be created")
+        _ <- Hdfs.value(Files.move(file, new File(destDir, file.getName)))
       } yield ()
-    )
 
   /** Convert a Hdfs operation that depends on a temporary file into a normal Hdfs operation */
   def hdfsWithTempFile[A](raw: File, fileName: String, action: File => Hdfs[A]): Hdfs[A] =

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/UploadSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/UploadSpec.scala
@@ -22,8 +22,6 @@ import au.com.cba.omnia.thermometer.core.Thermometer._
 import au.com.cba.omnia.thermometer.core.ThermometerSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids
 
-import au.com.cba.omnia.omnitool.{Error, Ok}
-
 object UploadSpec extends ThermometerSpec { def is = s2"""
 
 Upload Cascade
@@ -71,9 +69,11 @@ class UploadTestCascade(args: Args) extends Job(args) {
   override def clear()    {      /* we have no actual scalding jobs to run */ }
   override def run      = { true /* we have no actual scalding jobs to run */ }
 
-  UploadLogic.upload(source, domain, tablename, "{table}_{yyyyMMdd}*",
-    localRoot, archiveRoot, hdfsRoot, new Configuration) match {
-    case Ok(_)    => {}
-    case Error(e) => throw new Exception(s"Failed to upload file to HDFS: $e")
-  }
+  UploadLogic.upload(
+    source, domain, tablename, "{table}_{yyyyMMdd}*",
+    localRoot, archiveRoot, hdfsRoot, new Configuration
+  ).fold(
+    _ => (),
+    e => throw new Exception(s"Failed to upload file to HDFS: $e")
+  )
 }

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/UploadSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/UploadSpec.scala
@@ -22,7 +22,7 @@ import au.com.cba.omnia.thermometer.core.Thermometer._
 import au.com.cba.omnia.thermometer.core.ThermometerSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Ok}
+import au.com.cba.omnia.omnitool.{Error, Ok}
 
 object UploadSpec extends ThermometerSpec { def is = s2"""
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/InputSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/InputSpec.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import org.joda.time.DateTime
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Ok, Result}
+import au.com.cba.omnia.omnitool.{Error, Ok}
 
 class InputSpec extends Specification { def is = s2"""
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/PushSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/PushSpec.scala
@@ -22,7 +22,9 @@ import java.io.File
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.conf.Configuration
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Hdfs, Ok, Result}
+import au.com.cba.omnia.omnitool.{Error, Ok}
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 class PushSpec extends Specification { def is = s2"""
 

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerCascade.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerCascade.scala
@@ -22,7 +22,7 @@ import com.twitter.scalding._, TDsl._
 
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Ok}
+import au.com.cba.omnia.omnitool.{Error, Ok}
 
 import au.com.cba.omnia.maestro.api._, Maestro._
 import au.com.cba.omnia.maestro.example.thrift.{Account, Customer}

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerExecution.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerExecution.scala
@@ -18,7 +18,10 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
 
 import com.twitter.scalding.{Config, Execution}
 
+import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
+
 import au.com.cba.omnia.maestro.api.exec._, Maestro._
+
 import au.com.cba.omnia.maestro.example.thrift.{Account, Customer}
 
 /** Configuration for a customer execution example */
@@ -42,9 +45,7 @@ case class CustomerConfig(config: Config) {
     partition   = Partition.byField(Fields[Customer].Cat),
     tablename   = "by_cat"
   )
-  val writeToCatTableQuery = QueryConfig(
-    name        = "test",
-    settings    = Map(HIVEMERGEMAPFILES -> "true"),
+  val queries = List(
     s"INSERT OVERWRITE TABLE ${catTable.name} PARTITION (partition_cat) SELECT id, name, acct, cat, sub_cat, -10, effective_date, cat AS partition_cat FROM ${dateTable.name}",
     s"SELECT COUNT(*) FROM ${catTable.name}"
   )
@@ -52,7 +53,6 @@ case class CustomerConfig(config: Config) {
 
 /** Customer execution example */
 object CustomerExecution {
-
   /** Create an example customer execution */
   def execute: Execution[(LoadSuccess, Long)] = for {
     conf           <- Execution.getConfig.map(CustomerConfig(_))
@@ -61,6 +61,6 @@ object CustomerExecution {
     (pipe, ldInfo) <- load[Customer](conf.load, uploadInfo.files)
     loadSuccess    <- ldInfo.withSuccess
     (count1, _)    <- viewHive(conf.dateTable, pipe) zip viewHive(conf.catTable, pipe)
-    _              <- hiveQuery(conf.writeToCatTableQuery)
+    _              <- Execution.fromHive(Hive.queries(conf.queries), _.setVar(HIVEMERGEMAPFILES, "true"))
   } yield (loadSuccess, count1)
 }

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerUploadExample.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerUploadExample.scala
@@ -21,7 +21,7 @@ import scalaz._, Scalaz._
 import au.com.cba.omnia.maestro.api.Maestro
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
-import au.com.cba.omnia.permafrost.hdfs.{Error, Ok, Result}
+import au.com.cba.omnia.omnitool.{Error, Ok, Result}
 
 class CustomerUploadExample(args: Args) extends Maestro[Customer](args) {
   val hdfsRoot    = args("hdfs-root")

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerUploadExample.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerUploadExample.scala
@@ -21,8 +21,6 @@ import scalaz._, Scalaz._
 import au.com.cba.omnia.maestro.api.Maestro
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
-import au.com.cba.omnia.omnitool.{Error, Ok, Result}
-
 class CustomerUploadExample(args: Args) extends Maestro[Customer](args) {
   val hdfsRoot    = args("hdfs-root")
   val source      = "customer"
@@ -35,15 +33,21 @@ class CustomerUploadExample(args: Args) extends Maestro[Customer](args) {
   val byDateResult = Maestro.upload(source, domain, "by_date", filePattern, localRoot, archiveRoot, hdfsRoot, conf)
   val byIdResult   = Maestro.upload(source, domain, "by_id",   filePattern, localRoot, archiveRoot, hdfsRoot, conf)
 
-  List(byDateResult, byIdResult).sequence_ match {
-    case Error(_) => {
+  List(byDateResult, byIdResult).sequence_.foldAll(
+    result => {
+      // continue with post-processing here
+    },
+    errorMsg => {
       // do not post-process files when there was an error copying them
       // report the error here
-      ()
+    },
+    exception => {
+      // do not post-process files when there was an error copying them
+      // report the error here
+    },
+    (errorMsg, exception) => {
+      // do not post-process files when there was an error copying them
+      // report the error here
     }
-    case Ok(()) => {
-      // continue with post-processing here
-      ()
-    }
-  }
+  )
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -36,7 +36,7 @@ object build extends Build {
   val parquetVersion     = "1.2.5-cdh4.6.0-p485"
 
   lazy val standardSettings: Seq[Sett] =
-    Defaults.defaultSettings ++
+    Defaults.coreDefaultSettings ++
     uniformDependencySettings ++
     uniform.docSettings("https://github.com/CommBank/maestro")
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -31,8 +31,8 @@ object build extends Build {
   type Sett = Def.Setting[_]
 
   val thermometerVersion = "0.5.2-20141203051209-fb24dd1"
-  val ebenezerVersion    = "0.11.1-20141203221922-0f6ecc9"
-  val omnitoolVersion    = "1.3.0-20141009013528-4a9aa95"
+  val ebenezerVersion    = "0.12.0-20150106020438-03e71bf"
+  val omnitoolVersion    = "1.5.0-20150105001358-0e640c9"
   val parquetVersion     = "1.2.5-cdh4.6.0-p485"
 
   lazy val standardSettings: Seq[Sett] =
@@ -82,8 +82,8 @@ object build extends Build {
       ) ++ depend.scalaz() ++ depend.scalding() ++ depend.hadoop()
         ++ depend.shapeless() ++ depend.testing() ++ depend.time()
         ++ depend.omnia("ebenezer-hive", ebenezerVersion)
-        ++ depend.omnia("permafrost",    "0.1.0-20141203052129-fbfcb09")
-        ++ depend.omnia("edge",          "3.1.0-20141204003732-fe6fa15")
+        ++ depend.omnia("permafrost",    "0.2.0-20150105050042-0c1c388")
+        ++ depend.omnia("edge",          "3.2.0-20150105054720-4e7ae23")
         ++ depend.omnia("humbug-core",   "0.3.0-20140918054014-3066286")
         ++ depend.omnia("omnitool-time", omnitoolVersion)
         ++ depend.omnia("omnitool-file", omnitoolVersion)

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "1.15.0"
+version in ThisBuild := "1.16.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Takes advantage of the Hive monad from Ebenezer and all corresponding changes.

* `Result` is now in omnitool instead of permafrost.
* Use `fold` on `Result` instead of pattern matching.
* `fromHive` for Execution.
* Deprecated `QueryExecution`.
* Added Hive and Hdfs to api package.

This also closes #250.