### PR TITLE
Multiple sqoop queries fix

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -87,7 +87,7 @@ object build extends Build {
         ++ depend.omnia("humbug-core",   "0.3.0-20140918054014-3066286")
         ++ depend.omnia("omnitool-time", omnitoolVersion)
         ++ depend.omnia("omnitool-file", omnitoolVersion)
-        ++ depend.omnia("parlour",       "1.6.0-20150109022704-83555c4")
+        ++ depend.omnia("parlour",       "1.6.0-20150112235023-c8f2928")
         ++ Seq(
           "commons-validator"  % "commons-validator" % "1.4.0",
           "org.apache.commons" % "commons-compress"  % "1.8.1",


### PR DESCRIPTION
When importing data using Sqoop using a query Sqoop creates a java class and jar with a generic name. If there are 2 sqoop imports in the same job they will have the same name and clash causing the second import to fail.

This sets a unique class name for each sqoop job.

This closes #286.