### PR TITLE
The load return pipe provides a smaller number of larger splits

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/CombinedSequenceFile.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/CombinedSequenceFile.scala
@@ -1,0 +1,118 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.scalding
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.mapred._
+import org.apache.hadoop.mapred.lib._
+
+import cascading.flow.FlowProcess
+import cascading.scheme.Scheme
+import cascading.scheme.hadoop.{WritableSequenceFile => CHWritableSequenceFile}
+import cascading.tap.Tap
+import cascading.tuple.Fields
+
+import com.twitter.scalding._
+
+/** Keys for job conf properties */
+object ConfKeys {
+  val combinedSeqFileMaxSplitSize = "maestro.combinedseqfile.max.split.size"
+}
+
+/** A WritableSequenceFile which merges the input splits sent to downstream mappers. */
+class CombinedSequenceFile[K <: Writable : Manifest, V <: Writable : Manifest](
+  val path: String, splitSize: Long
+) extends WritableSequenceFile[K, V](path, new Fields(0, 1)) {
+
+  override def hdfsScheme =
+    (new CombinedSequenceFileScheme(fields, keyType, valueType, splitSize))
+      .asInstanceOf[Scheme[JobConf,RecordReader[_,_],OutputCollector[_,_],_,_]]
+}
+
+/** Factory for CombinedSequenceFile */
+object CombinedSequenceFile {
+  def apply[K <: Writable : Manifest, V <: Writable : Manifest](path: String, splitSize: Long) =
+    new CombinedSequenceFile[K, V](path, splitSize)
+}
+
+/**
+  * The cascading scheme for CombinedSequenceFile
+  *
+  * We only merge the splits sent to downstream mappers, not the data coming
+  * from upstream.
+  */
+class CombinedSequenceFileScheme(
+  fields: Fields,
+  keyType: Class[_ <: Writable],
+  valueType: Class[_ <: Writable],
+  splitSize: Long
+) extends CHWritableSequenceFile(fields, keyType, valueType) {
+  override def sourceConfInit(
+    flowProcess: FlowProcess[JobConf],
+    tap: Tap[JobConf, RecordReader[_,_], OutputCollector[_,_]],
+    conf: JobConf
+  ) {
+    conf.setLong(ConfKeys.combinedSeqFileMaxSplitSize, splitSize)
+    conf.setInputFormat(classOf[CombineSequenceFileInputFormat[_,_]])
+  }
+}
+
+/**
+  * The input format for CombinedSequenceFile
+  *
+  * When we upgrade to a later version of hadoop, we should be able to remove
+  * this class in favor of hadoop's version.
+  */
+class CombineSequenceFileInputFormat[K,V]() extends CombineFileInputFormat[K,V] {
+
+  override def getSplits(conf: JobConf, numSplits: Int): Array[InputSplit] = {
+    val maxSplitSize = conf.getLong(ConfKeys.combinedSeqFileMaxSplitSize, -1L)
+    if (maxSplitSize < 0L) { throw new Exception(s"Could not find configuration parameter ${ConfKeys.combinedSeqFileMaxSplitSize}")}
+    setMaxSplitSize(maxSplitSize)
+
+    super.getSplits(conf, numSplits)
+  }
+
+  override def getRecordReader(split: InputSplit, conf: JobConf, reporter: Reporter): RecordReader[K,V] = {
+    val innerReader = classOf[SequenceFileRecordReaderWrapper[K,V]].asInstanceOf[Class[RecordReader[K,V]]]
+    new CombineFileRecordReader(conf, split.asInstanceOf[CombineFileSplit], reporter, innerReader)
+  }
+}
+
+/**
+  * The reader that CombineFileRecordReader delegates to to read from the sequence file
+  *
+  * This is just a wrapper that converts the (CombineFileSplit, index) pair supplied
+  * by CombineFileRecordReader into the FileSplit required by SequenceFileInputFormat
+  */
+class SequenceFileRecordReaderWrapper[K,V](split: CombineFileSplit, conf: Configuration, reporter: Reporter, idx: Integer) extends RecordReader[K,V] {
+  val fileSplit = new FileSplit(
+    split.getPath(idx),
+    split.getOffset(idx),
+    split.getLength(idx),
+    split.getLocations()
+  )
+  val jobConf = conf.asInstanceOf[JobConf]
+  val inner   = new SequenceFileInputFormat[K,V]().getRecordReader(fileSplit, jobConf, reporter)
+
+  def next(key: K, value: V): Boolean = inner.next(key, value)
+  def close { inner.close }
+
+  def createKey:   K     = inner.createKey
+  def createValue: V     = inner.createValue
+  def getPos:      Long  = inner.getPos
+  def getProgress: Float = inner.getProgress
+}

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/Paths.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/Paths.scala
@@ -12,8 +12,18 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.1.0"
+package au.com.cba.omnia.maestro.core.scalding
 
-uniqueVersionSettings
+import cascading.tap.hadoop.Hfs
 
-licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+import com.twitter.scalding.Execution
+
+/** Executions that return paths */
+object Paths {
+  /** Return the temporary directory for this job */
+  def tempDir : Execution[String] =
+    Execution.getConfig.map(conf => {
+      val jobConf = ConfHelper.getHadoopConf(conf)
+      Hfs.getTempPath(jobConf).toString
+    })
+}

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadExecutionSpec.scala
@@ -17,8 +17,6 @@ package au.com.cba.omnia.maestro.core.task
 import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
 
 import au.com.cba.omnia.maestro.core.clean.Clean
-import au.com.cba.omnia.maestro.core.codec.{Decode, Tag}
-import au.com.cba.omnia.maestro.core.data.Field
 import au.com.cba.omnia.maestro.core.filter.RowFilter
 import au.com.cba.omnia.maestro.core.split.Splitter
 import au.com.cba.omnia.maestro.core.time.TimeSource
@@ -28,7 +26,7 @@ import au.com.cba.omnia.maestro.core.thrift.scrooge.StringPair
 
 private object LoadExec extends LoadExecution
 
-object LoadExecutionSpec extends ThermometerSpec { def is = s2"""
+object LoadExecutionSpec extends ThermometerSpec with StringPairSupport { def is = s2"""
 
 Load execution properties
 =========================
@@ -41,22 +39,6 @@ Load execution properties
   calculates the right number of rows after filtering            $filtered
 
 """
-
-  implicit val StringPairDecode: Decode[StringPair] = for {
-    first  <- Decode.of[String]
-    second <- Decode.of[String]
-  } yield StringPair(first, second)
-
-  implicit val StringPairTag: Tag[StringPair] = {
-    val fields =
-      Field("FIRST", (p:StringPair) => p.first) +:
-    Field("SECOND",(p:StringPair) => p.second) +:
-    Stream.continually[Field[StringPair,String]](
-      Field("UNKNOWN", _ => throw new Exception("invalid field"))
-    )
-
-    Tag(_ zip fields)
-  }
 
   val conf = LoadConfig[StringPair](errors = "errors", timeSource = TimeSource.now(), none = "null")
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadViewExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadViewExecutionSpec.scala
@@ -1,0 +1,132 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.task
+
+import java.io._
+
+import scala.util.Random
+
+import com.twitter.scalding.Execution
+import com.twitter.scalding.typed.TypedPipe
+
+import cascading.tap.hadoop.HfsProps
+
+import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
+
+import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
+import au.com.cba.omnia.thermometer.fact.Fact
+import au.com.cba.omnia.thermometer.hive.HiveSupport
+
+import au.com.cba.omnia.maestro.core.clean.Clean
+import au.com.cba.omnia.maestro.core.filter.RowFilter
+import au.com.cba.omnia.maestro.core.hive.HiveTable
+import au.com.cba.omnia.maestro.core.partition.Partition
+import au.com.cba.omnia.maestro.core.scalding.ExecutionOps._
+import au.com.cba.omnia.maestro.core.split.Splitter
+import au.com.cba.omnia.maestro.core.time.TimeSource
+import au.com.cba.omnia.maestro.core.validate.Validator
+
+import au.com.cba.omnia.maestro.core.thrift.scrooge.StringPair
+
+object LoadViewExecutionSpec extends ThermometerSpec with StringPairSupport with HiveSupport { def is = s2"""
+
+Load + View execution properties
+================================
+
+  load + view should merge splits      $viewMerges
+  load + viewHive should merge splits  $viewHiveMerges
+
+"""
+
+  val date = "today"
+
+  def loadConf = LoadConfig[StringPair](
+    errors = "errors",
+    timeSource = TimeSource.predetermined(date)
+  )
+
+  def viewMerges = {
+    val inputFile = dir + "/view/input"
+    val outputDir = dir + "/view/output"
+    val viewConf  = ViewConfig[StringPair, String](
+      partition   = Partition(List("SECOND"), _.second, "%s"),
+      output      = outputDir
+    )
+
+    // the date in the second column is pre-determined, hence only one partition
+    // with path $outputDir/$date
+    testMerge(
+      inputFile,
+      s"$outputDir/$date",
+      pipe => Exec.view[StringPair, String](viewConf, pipe)
+    )
+  }
+
+  def viewHiveMerges = {
+    val inputFile = dir + "/viewHive/input"
+    val outputDir = dir + "/viewHive/output"
+    val hiveTable = HiveTable[StringPair]("mydb", "mytbl", Some(outputDir))
+
+    testMerge(
+      inputFile,
+      outputDir,
+      pipe => Exec.viewHive(hiveTable, pipe)
+    )
+  }
+
+  def testMerge(inputFile: String, outputDir: String, writeOutput: TypedPipe[StringPair] => Execution[_]) = {
+    val kb = 1024
+
+    val exec = for {
+      _         <- Execution.from(writeInput(inputFile, 10*kb))
+      (pipe, _) <- Exec.load(loadConf.copy(splitSize = 5*kb), List(inputFile))
+      _         <- writeOutput(pipe)
+    } yield ()
+
+    jobConf.setInt("fs.local.block.size", kb)
+    executesOk(exec)
+    facts(
+      // input gets blown up into larger temp sequence file, so not sure of the
+      // exact number of blocks we are merging, but the blow up should not be
+      // anywhere near a factor of 5, so we expect the number of final files to
+      // be less than 10
+      Fact(_.glob(outputDir </> "part-*").length must be_>(1) and be_<(10))
+    )
+  }
+
+  // write input with 31 chars per line
+  // with the newline, this gives 32 chars per line, and as we are using
+  // alphanumeric chars with UTF8 format, we get 32 bytes per line
+  def writeInput(path: String, length: Int) {
+    val sep = '|'
+    val file = new File(path)
+    if (!file.getParentFile.mkdirs) { throw new Exception(s"couldn't create parent dirs to $path") }
+    if (!file.createNewFile) { throw new Exception(s"couldn't create $path") }
+
+    val writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"))
+    try {
+      val perLine = 32
+        (new Random).alphanumeric
+        .filter(_ != sep)
+        .grouped(perLine-1).map(_.mkString("", "", "\n"))
+        .take(length / perLine)
+        .foreach(writer.write(_))
+    } finally {
+      writer.close
+    }
+  }
+
+  private object Exec extends LoadExecution with ViewExecution
+}

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/StringPairSupport.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/StringPairSupport.scala
@@ -1,0 +1,39 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.task
+
+import au.com.cba.omnia.maestro.core.data.Field
+import au.com.cba.omnia.maestro.core.codec.{Decode, Tag}
+
+import au.com.cba.omnia.maestro.core.thrift.scrooge.StringPair
+
+trait StringPairSupport {
+
+  implicit val StringPairDecode: Decode[StringPair] = for {
+    first  <- Decode.of[String]
+    second <- Decode.of[String]
+  } yield StringPair(first, second)
+
+  implicit val StringPairTag: Tag[StringPair] = {
+    val fields =
+      Field("FIRST", (p:StringPair) => p.first) +:
+      Field("SECOND",(p:StringPair) => p.second) +:
+      Stream.continually[Field[StringPair,String]](
+        Field("UNKNOWN", _ => throw new Exception("invalid field"))
+      )
+
+    Tag(_ zip fields)
+  }
+}


### PR DESCRIPTION
We also switch to using a compact encoding for the temp sequence files.

The load pipe split size is configurable.

NOTE: I have not yet tested this on the cluster against a real load, but will do so before merging to master.