### PR TITLE
Generate key path fix

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
@@ -180,19 +180,17 @@ object LoadEx {
     config: LoadConfig[A], sources: List[String]
   ): Execution[(TypedPipe[A], LoadInfo)] = {
 
-    val resolvePath = (srcPath: Path) =>
-      for {
-        isDir <- Hdfs.isDirectory(srcPath)
-        paths <- if (!isDir) Hdfs.value(List(srcPath))
-                 else Hdfs.files(srcPath)
-      } yield paths
+    def resolvePath(srcPath: Path) = for {
+      isDir <- Hdfs.isDirectory(srcPath)
+      paths <- if (!isDir) Hdfs.value(List(srcPath))
+               else Hdfs.files(srcPath)
+    } yield paths
 
-    val resolvePaths = (srcPaths: List[String]) =>
-      for {
-        fs       <- Hdfs.filesystem
-        paths    =  srcPaths.map(Hdfs.path(_))
-        resPaths <- paths.map(resolvePath).sequence
-      } yield resPaths.flatten
+    def resolvePaths(srcPaths: List[String]) = for {
+      fs       <- Hdfs.filesystem
+      paths    =  srcPaths.map(Hdfs.path(_))
+      resPaths <- paths.map(resolvePath).sequence
+    } yield resPaths.flatten
 
     for {
       rawRows <- if (!config.generateKey) Execution.from(pipeWithDate(sources, config.timeSource))

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
@@ -190,13 +190,12 @@ object LoadEx {
       fs       <- Hdfs.filesystem
       paths    =  srcPaths.map(Hdfs.path(_))
       resPaths <- paths.map(resolvePath).sequence
-    } yield resPaths.flatten
+    } yield resPaths.flatten.map(_.toString)
 
     for {
-      rawRows <- if (!config.generateKey) Execution.from(pipeWithDate(sources, config.timeSource))
-                 else Execution.fromHdfs(resolvePaths(sources)).map { rSources =>
-                        pipeWithDateAndKey(rSources.map(_.toString), config.timeSource)
-                 }
+      rawRows      <- if (!config.generateKey) Execution.from(pipeWithDate(sources, config.timeSource))
+                      else Execution.fromHdfs(resolvePaths(sources))
+                             .map(rSources => pipeWithDateAndKey(rSources, config.timeSource))
       (pipe, info) <-
         Execution.withId { id => Paths.tempDir.flatMap { tmpDir => {
           val stat        = Stat(StatKeys.tuplesFiltered)(id)

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
@@ -166,7 +166,11 @@ trait LoadExecution {
     for {
       conf         <- Execution.getConfig
       fs           =  FileSystem.get(ConfHelper.getHadoopConf(conf))
-      srcsResolved =  sources.map(pathString => fs.resolvePath(new Path(pathString)))
+      srcsResolved = sources.map (new Path(_))
+                       .flatMap(path =>
+                         if (!fs.isDirectory(path)) List(path)
+                         else fs.globStatus(new Path(path, "*")).map(_.getPath())
+                       ).map(fs.resolvePath)
 //      _            <- Execution.from(srcsResolved.map(source => println(source)))  // debugging
       res          <- LoadEx.execution[A](config, srcsResolved.map(_.toString))
     } yield res

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadExecutionSpec.scala
@@ -37,6 +37,7 @@ Load execution properties
   returns the right load info for an acceptable number of errors $someErrors
   returns the right load info for too many errors                $manyErrors
   calculates the right number of rows after filtering            $filtered
+  generating keys doesn't throw exceptions                       $normalGenKey
 
 """
 
@@ -85,6 +86,15 @@ Load execution properties
       val filteredConf = conf.copy(errorThreshold = 0.25, filter = RowFilter.byRowLeader("D"))
       val exec         = LoadExec.load[StringPair](filteredConf, List("filtered"))
       executesSuccessfully(exec)._2 must_== LoadSuccess(5, 3, 3, 0)
+    }
+  }
+
+  // This checks for lack of exceptions, but not success - a new thrift type is required.
+  val confGenKey = LoadConfig[StringPair](errors = "errors", timeSource = TimeSource.now(), none = "null", generateKey = true)
+  def normalGenKey = {
+    withEnvironment(path(getClass.getResource("/load-execution").toString)) {
+      val exec = LoadExec.load[StringPair](confGenKey, List("normal"))
+      executesSuccessfully(exec)._2 must_== LoadFailure(4, 4, 0, 4)
     }
   }
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -30,7 +30,7 @@ import au.com.cba.omnia.humbug.HumbugSBT._
 object build extends Build {
   type Sett = Def.Setting[_]
 
-  val thermometerVersion = "0.5.3-20150113044449-b47d6dd"
+  val thermometerVersion = "0.5.3-20150221124731-40453fc"
   val ebenezerVersion    = "0.12.0-20150123010146-98a02be"
   val omnitoolVersion    = "1.5.0-20150113041805-fef6da5"
   val parquetVersion     = "1.2.5-cdh4.6.0-p485"


### PR DESCRIPTION
This fix just always expands the `sources` passed to `load` to the full paths for all files.