### PR TITLE
CDH5 upgrade

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/ViewExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/ViewExecution.scala
@@ -19,10 +19,12 @@ import com.twitter.scalding.{Execution, TupleSetter, TypedPipe}
 import com.twitter.scrooge.ThriftStruct
 
 import au.com.cba.omnia.ebenezer.scrooge.PartitionParquetScroogeSource
+import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
 
 import au.com.cba.omnia.maestro.core.hive.HiveTable
 import au.com.cba.omnia.maestro.core.partition.Partition
 import au.com.cba.omnia.maestro.core.scalding.StatKeys
+import au.com.cba.omnia.maestro.core.scalding.ExecutionOps._
 
 /**
   * Configuration options for write pipes to HDFS files.
@@ -61,7 +63,12 @@ trait ViewExecution {
     */
   def viewHive[A <: ThriftStruct : Manifest, ST](
     table: HiveTable[A, ST], pipe: TypedPipe[A], append: Boolean = true
-  ): Execution[Long] =
-    table.writeExecution(pipe, append)
-      .map(_.get(StatKeys.tuplesWritten).getOrElse(0))
+  ): Execution[Long] = for {
+    /* Creates the database upfront since when Hive is run concurrently uzing `zip` all but the
+     * first attempt fails.
+     * The Hive monad handles this so that the job doesn't fall over.
+     */
+    _ <- Execution.fromHive(Hive.createDatabase(table.database))
+    n <- table.writeExecution(pipe, append).map(_.get(StatKeys.tuplesWritten).getOrElse(0L))
+  } yield n
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -17,8 +17,6 @@ import Keys._
 
 import com.twitter.scrooge.ScroogeSBT._
 
-import sbtassembly.Plugin._, AssemblyKeys._
-
 import au.com.cba.omnia.uniform.core.standard.StandardProjectPlugin._
 import au.com.cba.omnia.uniform.core.version.UniqueVersionPlugin._
 import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
@@ -30,10 +28,9 @@ import au.com.cba.omnia.humbug.HumbugSBT._
 object build extends Build {
   type Sett = Def.Setting[_]
 
-  val thermometerVersion = "0.5.3-20150221124731-40453fc"
-  val ebenezerVersion    = "0.12.0-20150123010146-98a02be"
-  val omnitoolVersion    = "1.5.0-20150113041805-fef6da5"
-  val parquetVersion     = "1.2.5-cdh4.6.0-p485"
+  val thermometerVersion = "0.6.0-20150317012710-6f91910"
+  val ebenezerVersion    = "0.13.0-20150317050806-e331291"
+  val omnitoolVersion    = "1.7.0-20150316053109-4b4b011"
 
   lazy val standardSettings: Seq[Sett] =
     Defaults.coreDefaultSettings ++
@@ -49,7 +46,7 @@ object build extends Build {
     ++ uniform.ghsettings
     ++ Seq[Sett](
          publishArtifact := false
-       , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full)
+       , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
     )
   , aggregate = Seq(core, macros, api, test, schema)
   )
@@ -78,26 +75,26 @@ object build extends Build {
         (sourceDirectory) { _ / "test" / "thrift" / "scrooge" },
       libraryDependencies ++= Seq(
         "com.google.code.findbugs" % "jsr305"    % "2.0.3" // Needed for guava.
-      , "com.google.guava"         % "guava"     % "16.0.1"
+      // Can't be higher than this since there is a version incompatability with the version of bonecp (0.7.1) used by Hive
+      , "com.google.guava"         % "guava"     % "14.0.1"
       ) ++ depend.scalaz() ++ depend.scalding() ++ depend.hadoop()
         ++ depend.shapeless() ++ depend.testing() ++ depend.time()
+        ++ depend.parquet()
         ++ depend.omnia("ebenezer-hive", ebenezerVersion)
-        ++ depend.omnia("permafrost",    "0.2.0-20150113073328-8994d5b")
-        ++ depend.omnia("edge",          "3.2.0-20150113103131-d8aabb2")
-        ++ depend.omnia("humbug-core",   "0.3.0-20150220061008-1e3ca3f")
+        ++ depend.omnia("permafrost",    "0.4.0-20150316054624-9a8bd1f")
+        ++ depend.omnia("edge",          "3.2.0-20150316063342-0227f48")
+        ++ depend.omnia("humbug-core",   "0.4.0-20150316054843-8380712")
         ++ depend.omnia("omnitool-time", omnitoolVersion)
         ++ depend.omnia("omnitool-file", omnitoolVersion)
-        ++ depend.omnia("parlour",       "1.6.1-20150128235623-bd13c9b")
+        ++ depend.omnia("parlour",       "1.7.0-20150317022830-dfa570c")
         ++ Seq(
           "commons-validator"  % "commons-validator" % "1.4.0",
           "org.apache.commons" % "commons-compress"  % "1.8.1",
           "org.apache.hadoop"  % "hadoop-tools"      % depend.versions.hadoop % "provided",
-          "com.twitter"        % "parquet-cascading" % parquetVersion         % "provided",
           "au.com.cba.omnia"  %% "ebenezer-test"     % ebenezerVersion        % "test",
           "au.com.cba.omnia"  %% "thermometer-hive"  % thermometerVersion     % "test",
           "org.scalikejdbc"   %% "scalikejdbc"       % "2.1.2"                % "test",
-          "org.hsqldb"         % "hsqldb"            % "1.8.0.10"             % "test",
-          "com.twitter"        % "parquet-hive"      % parquetVersion         % "test"
+          "org.hsqldb"         % "hsqldb"            % "1.8.0.10"             % "test"
         ),
       parallelExecution in Test := false
     )
@@ -116,7 +113,7 @@ object build extends Build {
          , "org.scalamacros" %% "quasiquotes"    % "2.0.0"
          , "com.twitter"      % "util-eval_2.10" % "6.22.1" % Test
          ) ++ depend.testing())
-       , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.0" cross CrossVersion.full)
+       , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
     )
   ).dependsOn(core)
    .dependsOn(test % "test")
@@ -146,9 +143,7 @@ object build extends Build {
     ++ uniformAssemblySettings
     ++ uniformThriftSettings
     ++ Seq[Sett](
-         libraryDependencies ++= depend.hadoop() ++ Seq(
-           "com.twitter"      % "parquet-hive"      % parquetVersion % "test",
-           "com.twitter"      % "parquet-cascading" % parquetVersion % "provided",
+         libraryDependencies ++= depend.hadoop() ++ depend.parquet() ++ Seq(
            "org.scalikejdbc" %% "scalikejdbc"       % "2.1.2"               % "test",
            "org.hsqldb"       % "hsqldb"            % "1.8.0.10"            % "test"
          )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
   "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"
 )
 
-val uniformVersion = "0.7.0-20150113035718-6641c80"
+val uniformVersion = "0.8.0-20150316045728-f32c2c2"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
@@ -27,4 +27,4 @@ addSbtPlugin("au.com.cba.omnia" % "uniform-thrift"     % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
 
-addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.3.0-20150113043431-3dc2531")
+addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.4.0-20150316054843-8380712")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.1.0"
+version in ThisBuild := "2.2.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
CDH5 upgrade and force view execution to create the hive database.
This prevents the concurrent attempt to create the database within
HiveTap from failing and crashing the job.