### PR TITLE
Better stack trace for `RichExecution.from...` and adds `RichExecution.fromResult`

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
@@ -107,10 +107,7 @@ case class RichExecutionObject(exec: Execution.type) {
 
   /** Changes from an action that produces a scalaz Disjunction to an Execution. */
   def fromEither[T](disjunction: => String \/ T): Execution[T] =
-    Execution.fromFuture(_ => disjunction.fold(
-      msg => Future.failed(new Exception(msg)),
-      x   => Future.successful(x)
-    ))
+    fromResult(disjunction.fold(Result.fail, Result.ok))
 
   /**
     * Helper function to convert a result to a future.

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
@@ -1,0 +1,56 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.scalding
+
+import scala.util.Failure
+
+import com.twitter.scalding.Execution
+
+import org.specs2.matcher.Matcher
+
+import au.com.cba.omnia.thermometer.core.ThermometerSpec
+import au.com.cba.omnia.thermometer.hive.HiveSupport
+
+import au.com.cba.omnia.permafrost.hdfs.Hdfs
+
+import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
+
+import ExecutionOps._
+
+object Executions {
+  def hive  = Execution.fromHive(Hive.value(throw new Exception("test")))
+  def hdfs  = Execution.fromHdfs(Hdfs.value(throw new Exception("test")))
+}
+
+object RichExecutionSpec extends ThermometerSpec with HiveSupport { def is = s2"""
+
+Rich Execution
+==============
+
+The RichExecution object should:
+  provide useful exception information for `fromHive` $hive
+  provide useful exception information for `fromHdfs` $hdfs
+
+"""
+
+  def hive = Executions.hive must beFailureWithClass(Executions)
+
+  def hdfs = Executions.hdfs must beFailureWithClass(Executions)
+
+  def beFailureWithClass[A](clazz: Any): Matcher[Execution[A]] =
+    (execution: Execution[A]) => execute(execution) must beLike {
+      case Failure(t) => t.getStackTrace()(1).getClassName must_== clazz.getClass.getName
+    }
+}

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
@@ -23,6 +23,8 @@ import org.specs2.matcher.Matcher
 import au.com.cba.omnia.thermometer.core.ThermometerSpec
 import au.com.cba.omnia.thermometer.hive.HiveSupport
 
+import au.com.cba.omnia.omnitool.Result
+
 import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
 import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
@@ -30,8 +32,9 @@ import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
 import ExecutionOps._
 
 object Executions {
-  def hive  = Execution.fromHive(Hive.value(throw new Exception("test")))
-  def hdfs  = Execution.fromHdfs(Hdfs.value(throw new Exception("test")))
+  def hive   = Execution.fromHive(Hive.value(throw new Exception("test")))
+  def hdfs   = Execution.fromHdfs(Hdfs.value(throw new Exception("test")))
+  def result = Execution.fromResult(Result.fail("error"))
 }
 
 object RichExecutionSpec extends ThermometerSpec with HiveSupport { def is = s2"""
@@ -40,14 +43,15 @@ Rich Execution
 ==============
 
 The RichExecution object should:
-  provide useful exception information for `fromHive` $hive
-  provide useful exception information for `fromHdfs` $hdfs
+  provide useful exception information for `fromHive`   $hive
+  provide useful exception information for `fromHdfs`   $hdfs
+  provide useful exception information for `fromResult` $result
 
 """
 
-  def hive = Executions.hive must beFailureWithClass(Executions)
-
-  def hdfs = Executions.hdfs must beFailureWithClass(Executions)
+  def hive   = Executions.hive   must beFailureWithClass(Executions)
+  def hdfs   = Executions.hdfs   must beFailureWithClass(Executions)
+  def result = Executions.result must beFailureWithClass(Executions)
 
   def beFailureWithClass[A](clazz: Any): Matcher[Execution[A]] =
     (execution: Execution[A]) => execute(execution) must beLike {

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
@@ -16,6 +16,8 @@ package au.com.cba.omnia.maestro.core.scalding
 
 import scala.util.Failure
 
+import scalaz._, Scalaz._
+
 import com.twitter.scalding.Execution
 
 import org.specs2.matcher.Matcher
@@ -35,6 +37,7 @@ object Executions {
   def hive   = Execution.fromHive(Hive.value(throw new Exception("test")))
   def hdfs   = Execution.fromHdfs(Hdfs.value(throw new Exception("test")))
   def result = Execution.fromResult(Result.fail("error"))
+  def either = Execution.fromEither("error".left)
 }
 
 object RichExecutionSpec extends ThermometerSpec with HiveSupport { def is = s2"""
@@ -46,15 +49,17 @@ The RichExecution object should:
   provide useful exception information for `fromHive`   $hive
   provide useful exception information for `fromHdfs`   $hdfs
   provide useful exception information for `fromResult` $result
+  provide useful exception information for `fromEither` $either
 
 """
 
   def hive   = Executions.hive   must beFailureWithClass(Executions)
   def hdfs   = Executions.hdfs   must beFailureWithClass(Executions)
   def result = Executions.result must beFailureWithClass(Executions)
+  def either = Executions.either must beFailureWithClass(Executions, 2)
 
-  def beFailureWithClass[A](clazz: Any): Matcher[Execution[A]] =
+  def beFailureWithClass[A](clazz: Any, skip: Int = 1): Matcher[Execution[A]] =
     (execution: Execution[A]) => execute(execution) must beLike {
-      case Failure(t) => t.getStackTrace()(1).getClassName must_== clazz.getClass.getName
+      case Failure(t) => t.getStackTrace()(skip).getClassName must_== clazz.getClass.getName
     }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.3.1"
+version in ThisBuild := "2.3.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Changes the internals of `RichExecution` `fromHive`, `fromHdfs` and `fromEither` to provide a more useful stack trace. The stack trace now shows the location that `fromHdfs` or `fromHive` where called. This closes #326.

Also adds `fromResult`.