### PR TITLE
Adds ability to set JobNotReady and JobFailure as execution errors and recover them again.

### DIFF
--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/package.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/package.scala
@@ -29,6 +29,8 @@ package object api {
   val  JobNotReady     = au.com.cba.omnia.maestro.core.scalding.JobNotReady
   val  JobNeverReady   = au.com.cba.omnia.maestro.core.scalding.JobNeverReady
   val  JobFailure      = au.com.cba.omnia.maestro.core.scalding.JobFailure
+  val MaestroExecution = au.com.cba.omnia.maestro.core.scalding.MaestroExecution
+  val MX               = au.com.cba.omnia.maestro.core.scalding.MaestroExecution
 
   type HiveTable[A <: ThriftStruct, B] = au.com.cba.omnia.maestro.core.hive.HiveTable[A, B]
   type Partition[A, B] = au.com.cba.omnia.maestro.core.partition.Partition[A, B]

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroExecution.scala
@@ -1,0 +1,34 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.scalding
+
+import com.twitter.scalding.Execution
+
+/** Maestro specific Execution functions. */
+object MaestroExecution {
+  /** Creates an execution that has a [[JobNotReady]] error. */
+  def jobNotReady[T]: Execution[T] = Execution.from[T](throw JobNotReadyException)
+
+  /** Creates an execution that has a [[JobFailure]] error. */
+  def jobFailure[T](exitCode: Int = -1): Execution[T] =
+    Execution.from[T](throw new JobFailureException(exitCode))
+
+  /** Lifts a [[JobNotReady]] or [[JobFailure]] error into a JobStatus value for execution. */
+  def recoverJobStatus(execution: Execution[JobStatus]): Execution[JobStatus] =
+    execution.recoverWith {
+      case JobNotReadyException          => Execution.from(JobNotReady)
+      case JobFailureException(exitCode) => Execution.from(JobFailure(exitCode))
+    }
+}

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroJob.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroJob.scala
@@ -43,6 +43,24 @@ case class JobFailure(override val exitCode: Int) extends JobStatus {
   require(exitCode < 0, s"The exit code for a job failure must be < 0. Got $exitCode")
 }
 
+/**
+  * Exception representation of the [[JobNotReady]] status.
+  *
+  * This is used so that we can represent these statuses as errors that Execution understands.
+  * A better way would be to create a proper wrapper with Execution but this is a more lightweight
+  * bridging solution.
+  */
+case object JobNotReadyException extends Exception("Job not ready")
+
+/**
+  * Exception representation of the [[JobFailureStatus]] status.
+  *
+  * This is used so that we can represent these statuses as errors that Execution understands.
+  * A better way would be to create a proper wrapper with Execution but this is a more lightweight
+  * bridging solution.
+  */
+case class JobFailureException(exitCode: Int) extends Exception(s"Job failure with exit code $exitCode")
+
 /** Companion object for JobFailure to create a default JobFailure. */
 object JobFailure {
   /** Creates a default job failure with exit code -1. */
@@ -74,7 +92,7 @@ trait MaestroJob extends Serializable {
     val status = try {
       val (conf, mode) = ExApp.config(args)
       val execution    = if (conf.getArgs.boolean("attempts-exceeded")) attemptsExceeded else job
-      execution.waitFor(conf, mode).get
+      MaestroExecution.recoverJobStatus(execution).waitFor(conf, mode).get
     } catch {
       case NonFatal(ex) => {
         logger.error("error running execution", ex)

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/MaestroExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/MaestroExecutionSpec.scala
@@ -1,0 +1,37 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.core.scalding
+
+import au.com.cba.omnia.thermometer.core.ThermometerSpec
+
+object MaestroExecutionSpec extends ThermometerSpec { def is = s2"""
+
+Maestro Execution functions
+===========================
+
+Maestro Execution functions:
+  can recover `JobNotReadyError`  $jobNotReady
+  can recover `JobFailureError`   $jobFailure
+
+"""
+
+  def jobNotReady = {
+    executesSuccessfully(MaestroExecution.recoverJobStatus(MaestroExecution.jobNotReady)) must_== JobNotReady
+  }
+
+  def jobFailure = {
+    executesSuccessfully(MaestroExecution.recoverJobStatus(MaestroExecution.jobFailure(-2))) must_== JobFailure(-2)
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.6.0"
+version in ThisBuild := "2.7.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This should make some of the control flows much nicer. In particular when you want to return JobNotReady and then stop.