### PR TITLE
TimeSource.predetermined does not handle timezones

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/time/TimeSource.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/time/TimeSource.scala
@@ -36,14 +36,9 @@ object TimeSource {
   def predetermined(time: String): TimeSource =
     Predetermined(time)
 
-  /**
-    * Use a predetermined date as the time source
-    *
-    * Converts the time to UTC, which maintains backwards compatibility, but is
-    * different to our other time sources.
-    */
+  /** Use a predetermined date as the time source */
   def predetermined(time: DateTime, format: String = "yyyy-MM-dd"): TimeSource = {
-    val f = DateTimeFormat.forPattern(format).withZoneUTC
+    val f = DateTimeFormat.forPattern(format)
     predetermined(f.print(time))
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.7.1"
+version in ThisBuild := "2.7.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This fixes #265. Although this is arguably a regression,
it is in line with our other dates. This commit aims for consistency,
rather than providing a solution to our time zone issues.