### PR TITLE
Fixes `>>=` not work on Execution

### DIFF
--- a/maestro-api/src/test/scala/au/com/cba/omnia/maestro/api/test/SynxtaxSpec.scala
+++ b/maestro-api/src/test/scala/au/com/cba/omnia/maestro/api/test/SynxtaxSpec.scala
@@ -1,0 +1,46 @@
+//   Copyright 2014 Commonwealth Bank of Australia
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package au.com.cba.omnia.maestro.api.test
+
+import scalaz._, Scalaz._
+
+import com.twitter.scalding.Execution
+
+import org.specs2._
+
+import au.com.cba.omnia.maestro.api._, Maestro._
+
+
+/** 
+  * Checks that the different syntax and implicit resolutions work as expected.
+  * The fact that the code compiles is enough to ensure that the syntax works.
+  * Hence this test won't actually run anything.
+  */
+object SyntaxSpec extends Specification { def is = s2"""
+
+Maestro API Syntax Spec
+=======================
+
+ Scalaz syntax monad syntax works $bind
+
+"""
+
+  def bind = {
+    Execution.from(3) >>= (a => Execution.from(a + 3))
+    Execution.from(3) >> Execution.from(4)
+
+    true
+  }
+}

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
@@ -23,7 +23,7 @@ import com.twitter.scalding.{Config, Execution}
 
 import org.apache.hadoop.hive.conf.HiveConf
 
-import au.com.cba.omnia.omnitool.{Result, ResultantMonad, ResultantOps, ToResultantMonadOps}
+import au.com.cba.omnia.omnitool.{Result, ResultantMonad, ResultantOps, ResultantMonadOps}
 
 import au.com.cba.omnia.permafrost.hdfs.Hdfs
 
@@ -119,7 +119,7 @@ case class RichExecutionObject(exec: Execution.type) extends ResultantOps[Execut
 
 object ExecutionOps extends ExecutionOps
 
-trait ExecutionOps extends ToResultantMonadOps {
+trait ExecutionOps {
   /** Implicit conversion of an Execution instance to RichExecution. */
   implicit def executionToRichExecution[A](execution: Execution[A]): RichExecution[A] =
     RichExecution[A](execution)
@@ -141,6 +141,10 @@ trait ExecutionOps extends ToResultantMonadOps {
         .recoverWith[Result[A]]{ case thr => Execution.from(Result.exception[A](thr)) }
         .flatMap(f)       // flatMap over an Execution[Result[A]] that is overall equivalent to ma.
   }
+
+  /** Pimps a [[ResultantMonad]] to have access to the functions in [[ResultantMonadOps]]. */
+  implicit def ToResultantMonadOps[M[_], A](v: M[A])(implicit M0: ResultantMonad[M]): ResultantMonadOps[M, A] =
+    new ResultantMonadOps[M, A](v)
 }
 
 /**

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.9.0"
+version in ThisBuild := "2.9.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Changes RichExecutionOps to not pull in implicit conversions to `MonadOps` and `BindOps`.

`RichExecutionOps` was extending `ToResultantMonadOps` which also extends `ToMonadOps` and `ToPlusOps`. Since `RichExecutionOps` is not a companion object the implicits provided by `ToMonadOps` from `ToResultantOps` clashed with the `ToMonadOps` imported from Scalaz.

This changes `RichExecutionOps` to not extends `ToResultantMonadOps` and instead just provide an implicit conversion to `ResultantMonadOps`.

This fixes #372.