### PR TITLE
Upgrades to Scala 2.11

### DIFF
--- a/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/package.scala
+++ b/maestro-api/src/main/scala/au/com/cba/omnia/maestro/api/package.scala
@@ -14,8 +14,6 @@
 
 package au.com.cba.omnia.maestro
 
-import com.twitter.scrooge.ThriftStruct
-
 package object api {
   type MaestroJob      = au.com.cba.omnia.maestro.core.scalding.MaestroJob
   type MacroSupport    = au.com.cba.omnia.maestro.macros.MacroSupport

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/codec/Decode.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/codec/Decode.scala
@@ -12,17 +12,14 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package codec
+package au.com.cba.omnia.maestro.core.codec
 
 import scala.util.control.NonFatal
 import scala.reflect.runtime.universe.{typeOf, WeakTypeTag}
 
 import scalaz._, Scalaz._, \&/._
 
-import shapeless.{ProductTypeClass, TypeClassCompanion}
-
-import au.com.cba.omnia.maestro.core.data._
+import shapeless.{ProductTypeClass, ProductTypeClassCompanion}
 
 /**
   * Decoder for a list of strings.
@@ -56,7 +53,7 @@ case class Decode[A](run: (String, List[String], Int) => DecodeResult[(List[Stri
 }
 
 /** Encode companion object.*/
-object Decode extends TypeClassCompanion[Decode] {
+object Decode extends ProductTypeClassCompanion[Decode] {
   /** Encodes `A` as a list of string. `None` are replaced with the supplied `none` string.*/
   def decode[A: Decode](none: String, source: List[String]): DecodeResult[A] =
     Decode.of[A].decode(none, source)
@@ -124,10 +121,7 @@ object Decode extends TypeClassCompanion[Decode] {
       loop(DecodeOk(Vector()), source, n)
     })
 
-  implicit def ProductDecode[A]: Decode[A] =
-    macro shapeless.TypeClass.derive_impl[Decode, A]
-
-  implicit def DecodeTypeClass: ProductTypeClass[Decode] = new ProductTypeClass[Decode] {
+  val typeClass: ProductTypeClass[Decode] = new ProductTypeClass[Decode] {
     import shapeless._
 
     def emptyProduct =

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/codec/DecodeResult.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/codec/DecodeResult.scala
@@ -12,12 +12,12 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package codec
+package au.com.cba.omnia.maestro.core.codec
 
-import au.com.cba.omnia.maestro.core.data._
 import scala.util.control.NonFatal
+
 import scalaz._, Scalaz._, \&/._
+
 import shapeless.{ProductTypeClass, TypeClassCompanion}
 
 sealed trait Reason

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/hdfs/MaestroHdfs.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/hdfs/MaestroHdfs.scala
@@ -47,7 +47,7 @@ import Guard.{NotProcessed, IngestionComplete}
   * case class WidgetSalesConfig[T <: ThriftStruct : Decode : Tag : Manifest](...)
   * {
   *   ...
-  *   val inputs = Guard.expandTransferredPaths(s"${maestro.hdfsRoot}/source/${maestro.source}/${maestro.tablename}/*/*/*")
+  *   val inputs = Guard.expandTransferredPaths(s"${maestro.hdfsRoot}/source/${maestro.source}/${maestro.tablename}/part*")
   * }}}
   *
   * Notice that `Guard.expandTransferredPaths` executes immediately when the class is instantiated (returning a list of
@@ -63,7 +63,7 @@ import Guard.{NotProcessed, IngestionComplete}
   * case class WidgetSalesConfig[T <: ThriftStruct : Decode : Tag : Manifest](...)
   * {
   *   ...
-  *   val inputGlob = s"${maestro.hdfsRoot}/source/${maestro.source}/${maestro.tablename}/*/*/*"
+  *   val inputGlob = s"${maestro.hdfsRoot}/source/${maestro.source}/${maestro.tablename}/part*"
   * }}}
   *
   * Later in the file, we see where `inputs` was being used:

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/hive/HiveTable.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/hive/HiveTable.scala
@@ -14,11 +14,9 @@
 
 package au.com.cba.omnia.maestro.core.hive
 
-import scalaz._, Scalaz._
-import scalaz.syntax.monad._
+import scalaz.Scalaz._
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.fs.Path._
 
 import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREWAREHOUSE
@@ -211,15 +209,27 @@ case class UnpartitionedHiveTable[A <: ThriftStruct : Manifest](
 object HiveTable {
   /** Information need to address/describe a specific partitioned hive table.*/
   def apply[A <: ThriftStruct : Manifest, B : Manifest : TupleSetter](
+    database: String, table: String, partition: Partition[A, B]
+  ): HiveTable[A, (B, A)] =
+    PartitionedHiveTable(database, table, partition, None)
+
+  /** Information need to address/describe a specific partitioned hive table.*/
+  def apply[A <: ThriftStruct : Manifest, B : Manifest : TupleSetter](
     database: String, table: String, partition: Partition[A, B], path: String
   ): HiveTable[A, (B,A)] =
     PartitionedHiveTable(database, table, partition, Some(path))
 
   /** Information need to address/describe a specific partitioned hive table.*/
   def apply[A <: ThriftStruct : Manifest, B : Manifest : TupleSetter](
-    database: String, table: String, partition: Partition[A, B], pathOpt: Option[String] = None
+    database: String, table: String, partition: Partition[A, B], pathOpt: Option[String]
   ): HiveTable[A, (B, A)] =
     PartitionedHiveTable(database, table, partition, pathOpt)
+
+  /** Information need to address/describe a specific unpartitioned hive table.*/
+  def apply[A <: ThriftStruct : Manifest](
+    database: String, table: String
+  ): HiveTable[A, A] =
+    UnpartitionedHiveTable(database, table, None)
 
   /** Information need to address/describe a specific unpartitioned hive table.*/
   def apply[A <: ThriftStruct : Manifest](
@@ -229,7 +239,7 @@ object HiveTable {
 
   /** Information need to address/describe a specific unpartitioned hive table.*/
   def apply[A <: ThriftStruct : Manifest](
-    database: String, table: String, pathOpt: Option[String] = None
+    database: String, table: String, pathOpt: Option[String]
   ): HiveTable[A, A] =
     UnpartitionedHiveTable(database, table, pathOpt)
 }

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/Errors.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/Errors.scala
@@ -12,14 +12,15 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package scalding
+package au.com.cba.omnia.maestro.core.scalding
 
 import cascading.flow.FlowDef
 import cascading.pipe.Pipe
-import com.twitter.scalding._, typed.TypedSink, Dsl._, TDsl._
-import scalaz._, Scalaz._
 
+import com.twitter.scalding.{FieldConversions, Source, TypedPipe, TypedPsv}
+import com.twitter.scalding.typed.TypedSink
+
+import scalaz.{\/, -\/, \/-}
 
 object Errors extends FieldConversions {
 

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/RichExecution.scala
@@ -16,7 +16,7 @@ package au.com.cba.omnia.maestro.core.scalding
 
 import scala.concurrent.Future
 
-import scalaz._, Scalaz._
+import scalaz.{\/, Monad}
 import scalaz.\&/.{These, This, That, Both}
 
 import com.twitter.scalding.{Config, Execution}
@@ -31,8 +31,6 @@ import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
 
 /** Pimps an Execution instance. */
 case class RichExecution[A](execution: Execution[A]) {
-  import ExecutionOps._
-
   def withSubConfig(modifyConfig: Config => Config): Execution[A] =
     Execution.getConfigMode.flatMap { case (config, mode) =>
       Execution.fromFuture(cec => execution.run(modifyConfig(config), mode)(cec))

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
@@ -22,7 +22,7 @@ import scala.reflect.runtime.currentMirror
 import scala.util.control.NonFatal
 import scala.util.hashing.MurmurHash3
 
-import scalaz.{Tag => _, _}, Scalaz._
+import scalaz.\/
 
 import org.apache.hadoop.io.{BytesWritable, NullWritable}
 import org.apache.hadoop.fs.{FileSystem, Path}

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/LoadExecution.scala
@@ -220,28 +220,16 @@ object LoadEx {
     */
   def parseRows[A <: ThriftStruct : Decode : Tag : ClassTag](
     conf: LoadConfig[A], filterCounter: Stat, in: TypedPipe[RawRow]
-  ): TypedPipe[String \/ A] = {
-    val pipe = TypedPipeFactory { (flowDef, mode) =>
-      implicit val fd = flowDef
-      implicit val m  = mode
-
-      TypedPipe.from[(RawRow, FlowProcess[_])](
-        in.toPipe('row).eachTo('row, ('row, 'fp))(_ => new AddFlowProcess()),
-        ('row, 'fp)
-      )
-    }
-
-    pipe
-      .map { case (row, fp) => (conf.splitter.run(row.line) ++ row.extraFields, fp) }
-      .flatMap { case (parts, fp) => conf.filter.run(parts) match {
+  ): TypedPipe[String \/ A] =
+    in
+      .map(row => conf.splitter.run(row.line) ++ row.extraFields)
+      .flatMap(conf.filter.run(_) match {
         case Some(r) => Some(r)
         case None    => {
-          // Uses Cascading counter instead of Scalding. See `AddFlowProcess` for details.
-          fp.increment("maestro", "tuples_filtered", 1L)
+          filterCounter.inc
           None
         }
-      }}.map(decodeRow[A](conf))
-  }
+      }).map(decodeRow[A](conf))
 
   /** Decode and validate a single row. */
   def decodeRow[A <: ThriftStruct : Decode : Tag : ClassTag](conf: LoadConfig[A])(row: List[String])
@@ -388,28 +376,6 @@ class ExtractTime(timeSource: TimeSource)
 
     // representation of RawRow: tuple with string and List elements
     resultTuple.set(0, RawRow(line, List(timeSource.getTime(path))))
-    call.getOutputCollector.add(resultTuple)
-  }
-}
-
-/**
-  * Drops down to the Cascading level to get the FlowProcess.
-  *
-  * We do this so that we can then use the flow process later to increment a counter.
-  * The Scalding way of doing this seems to be broken see
-  * <a href="https://github.com/CommBank/maestro/issues/300">300</a>.
-  */
-class AddFlowProcess extends BaseOperation[Tuple](('row, 'fp)) with Function[Tuple] {
-  override def prepare(flow: FlowProcess[_], call: OperationCall[Tuple]): Unit = {
-    call.setContext(Tuple.size(2))
-  }
-
-  def operate(flow: FlowProcess[_], call: FunctionCall[Tuple]): Unit = {
-    val row         = call.getArguments.getObject(0)
-    val resultTuple = call.getContext
-
-    resultTuple.set(0, row)
-    resultTuple.set(1, flow)
     call.getOutputCollector.add(resultTuple)
   }
 }

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/SqoopExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/SqoopExecution.scala
@@ -15,6 +15,7 @@
 package au.com.cba.omnia.maestro.core.task
 
 import scala.util.Random
+import scala.reflect.{ClassTag, classTag}
 
 import java.io.File
 
@@ -292,13 +293,13 @@ object SqoopEx {
     } yield (importPath, count)
   }
 
-  def archive[C <: CompressionCodec : ClassManifest](
+  def archive[C <: CompressionCodec : ClassTag](
     src: String, dest: String
   ): Execution[Long] = {
     def modifyConfig(config: Config) = Config(config.toMap ++ Map(
       "mapred.output.compress"          -> "true",
       "mapred.output.compression.type"  -> "BLOCK",
-      "mapred.output.compression.codec" -> implicitly[ClassManifest[C]].erasure.getName
+      "mapred.output.compression.codec" -> classTag[C].runtimeClass.getName
     ))
 
     val execution = TypedPipe.from(TextLine(src))

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/SqoopExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/SqoopExecution.scala
@@ -27,15 +27,12 @@ import scalaz.Monoid
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.compress.{GzipCodec, CompressionCodec}
 
-//import com.cloudera.sqoop.SqoopOptions
-
 import cascading.flow.FlowDef
 
 import com.twitter.scalding._
 
 import com.cba.omnia.edge.source.compressible.CompressibleTypedTsv
 
-// import au.com.cba.omnia.parlour._
 import au.com.cba.omnia.parlour.SqoopSyntax.{ParlourExportDsl, ParlourImportDsl}
 import au.com.cba.omnia.parlour.{SqoopExecution => ParlourExecution, ParlourExportOptions, ParlourImportOptions, ParlourOptions}
 
@@ -240,12 +237,13 @@ object SqoopExecutionTest {
   def setupEnv(
     customMRHome: String = s"${System.getProperty("user.home")}/.ivy2/cache",
     customConnMan: Option[String] = None
-  ) {
+  ): Unit = {
     // very dodgy way of configuring sqoop for testing,
     // but these should only ever have one value each in a single testing run
     // and the configuration becomes an implementation details hidden from our API
     System.setProperty(SqoopEx.mrHomeKey, customMRHome)
     customConnMan.fold(System.clearProperty(SqoopEx.connManKey))(cm => System.setProperty(SqoopEx.connManKey, cm))
+    ()
   }
 }
 

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/UploadExecution.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/task/UploadExecution.scala
@@ -18,8 +18,6 @@ import java.io.{BufferedReader, FileReader, File}
 
 import scala.util.matching.Regex
 
-import scalaz._, Scalaz._
-
 import org.slf4j.{Logger, LoggerFactory}
 
 import org.apache.commons.io.input.ReversedLinesFileReader
@@ -245,7 +243,7 @@ object UploadEx {
 
   def matcher(conf: UploadConfig): Execution[List[DataFile]] = for {
     _     <- Execution.from {
-               logger.info("Start of pattern matching from ${conf.localIngestPath}")
+               logger.info(s"Start of pattern matching from ${conf.localIngestPath}")
                logger.info(conf.prettyPrint)
              }
     files <- Execution.fromEither(Input.findFiles(

--- a/maestro-core/src/test/resources/log4j.properties
+++ b/maestro-core/src/test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.rootLogger=ERROR,console
+hadoop.root.logger=ERROR,console

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/codec/DecodeSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/codec/DecodeSpec.scala
@@ -52,7 +52,7 @@ Decode witness
 
 """
 
-  val noneVal = "\0"
+  val noneVal = "\u0000"
 
   def primitive[A : Arbitrary : Decode : Encode] = prop { (v: A) =>
     Decode.decode(noneVal, Encode.encode(noneVal, v)) must_== DecodeOk(v)

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/codec/EncodeSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/codec/EncodeSpec.scala
@@ -48,20 +48,22 @@ Encode witness
 
 """
 
+  val noneVal = "\u0000"
+
   def primitive[A : Arbitrary : Encode](f: A => String) = prop((v: A) =>
-    Encode.encode("\0", v) must_== List(f(v))
+    Encode.encode(noneVal, v) must_== List(f(v))
   )
 
   def option = {
-    (Encode.encode("\0",   Option(3))            must_== List("3"))    and
-    (Encode.encode("\0",   Option.empty[Int])    must_== List("\0"))   and
-    (Encode.encode("\0",   Option("test"))       must_== List("test")) and
-    (Encode.encode("\0",   Option.empty[String]) must_== List("\0"))   and
-    (Encode.encode("null", Option.empty[String]) must_== List("null"))
+    (Encode.encode(noneVal,   Option(3))            must_== List("3"))     and
+    (Encode.encode(noneVal,   Option.empty[Int])    must_== List(noneVal)) and
+    (Encode.encode(noneVal,   Option("test"))       must_== List("test"))  and
+    (Encode.encode(noneVal,   Option.empty[String]) must_== List(noneVal)) and
+    (Encode.encode("null", Option.empty[String])    must_== List("null"))
   }
 
   def tuples = prop((b: Boolean, i: Int, l: Long, d: Double, s: String) =>
-    Encode.encode("\0", (b, i, l, d, s, (b, i, l, d, s))) must_== twice(List(
+    Encode.encode(noneVal, (b, i, l, d, s, (b, i, l, d, s))) must_== twice(List(
         b.toString
       , i.toString
       , l.toString
@@ -93,5 +95,5 @@ Encode witness
   case class Example(s: String, l: Long, n: Nested)
 
   implicit def EncodeIntEqual: Equal[Encode[Int]] =
-    Equal.equal((a, b) => a.run("\0", 0) == b.run("\0", 0))
+    Equal.equal((a, b) => a.run(noneVal, 0) == b.run(noneVal, 0))
 }

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/hdfs/MaestroHdfsSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/hdfs/MaestroHdfsSpec.scala
@@ -4,14 +4,14 @@ import org.apache.hadoop.conf.Configuration
 
 import org.specs2.execute.AsResult
 import org.specs2.matcher.FileMatchers
-import org.specs2.specification.AroundExample
+import org.specs2.specification.AroundEach
 
 import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
 
 import au.com.cba.omnia.permafrost.test.HdfsMatchers
 
 class MaestroHdfsSpec extends ThermometerSpec
-  with AroundExample
+  with AroundEach
   with FileMatchers
   with HdfsMatchers { def is = s2"""
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/scalding/RichExecutionSpec.scala
@@ -24,8 +24,7 @@ import org.scalacheck.Arbitrary, Arbitrary._
 
 import org.specs2.matcher.Matcher
 
-import au.com.cba.omnia.thermometer.core.ThermometerSpec
-import au.com.cba.omnia.thermometer.hive.HiveSupport
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
 import au.com.cba.omnia.omnitool.Result
 import au.com.cba.omnia.omnitool.test.OmnitoolProperties.resultantMonad
@@ -44,7 +43,7 @@ object Executions {
   def either = Execution.fromEither("error".left)
 }
 
-object RichExecutionSpec extends ThermometerSpec with HiveSupport { def is = s2"""
+object RichExecutionSpec extends ThermometerHiveSpec { def is = s2"""
 
 Rich Execution
 ==============

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadViewExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/LoadViewExecutionSpec.scala
@@ -26,24 +26,22 @@ import cascading.tap.hadoop.HfsProps
 import au.com.cba.omnia.ebenezer.scrooge.hive.Hive
 import au.com.cba.omnia.ebenezer.ParquetLogging
 
-import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
+import au.com.cba.omnia.thermometer.core.Thermometer._
 import au.com.cba.omnia.thermometer.fact.Fact
-import au.com.cba.omnia.thermometer.hive.HiveSupport
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
 import au.com.cba.omnia.maestro.core.clean.Clean
 import au.com.cba.omnia.maestro.core.filter.RowFilter
 import au.com.cba.omnia.maestro.core.hive.HiveTable
 import au.com.cba.omnia.maestro.core.partition.Partition
-import au.com.cba.omnia.maestro.core.scalding.ExecutionOps._
 import au.com.cba.omnia.maestro.core.split.Splitter
 import au.com.cba.omnia.maestro.core.time.TimeSource
 import au.com.cba.omnia.maestro.core.validate.Validator
 
 import au.com.cba.omnia.maestro.core.thrift.scrooge.StringPair
 
-object LoadViewExecutionSpec extends ThermometerSpec
+object LoadViewExecutionSpec extends ThermometerHiveSpec
     with StringPairSupport
-    with HiveSupport
     with ParquetLogging { def is = s2"""
 
 Load + View execution properties

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/SqoopExportExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/SqoopExportExecutionSpec.scala
@@ -198,6 +198,7 @@ object SqoopExportExecutionSpec
       )
     """).execute.apply()
 
+    ()
   }
 
   def testObjTableData(

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/SqoopImportExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/SqoopImportExecutionSpec.scala
@@ -25,7 +25,7 @@ import scalikejdbc.{SQL, AutoSession, ConnectionPool}
 
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 
-import org.specs2.specification.BeforeExample
+import org.specs2.specification.BeforeEach
 
 import au.com.cba.omnia.parlour.SqoopSyntax.{ParlourImportDsl,TeradataParlourImportDsl}
 
@@ -37,7 +37,6 @@ import au.com.cba.omnia.thermometer.core.{Thermometer, ThermometerRecordReader, 
 
 object SqoopImportExecutionSpec
   extends ThermometerSpec
-  with BeforeExample
   with SqoopExecution { def is = s2"""
   Sqoop Import Execution test
   ===========================
@@ -200,9 +199,10 @@ object SqoopImportExecutionSpec
     )
   }
 
-  override def before: Any = tableSetup(
-    connectionString, username, password, importTableName
-  )
+  override def before = {
+    super.before
+    tableSetup(connectionString, username, password, importTableName)
+  }
 
   object ImportPathFact {
     def apply(actualPath: String) = Fact(_ => actualPath must beEqualTo(s"$hdfsLandingPath/$timePath"))

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/ViewExecutionSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/task/ViewExecutionSpec.scala
@@ -14,13 +14,14 @@
 
 package au.com.cba.omnia.maestro.core.task
 
-import org.specs2.matcher.Matcher
-import org.specs2.execute.{Result => SpecResult}
+import scalaz.Scalaz._
 
-import au.com.cba.omnia.thermometer.core.{Thermometer, ThermometerSource, ThermometerSpec}, Thermometer._
+import org.specs2.matcher.Matcher
+
+import au.com.cba.omnia.thermometer.core.{Thermometer, ThermometerSource}, Thermometer._
 import au.com.cba.omnia.thermometer.fact.PathFactoid
 import au.com.cba.omnia.thermometer.fact.PathFactoids._
-import au.com.cba.omnia.thermometer.hive.HiveSupport
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
 import au.com.cba.omnia.ebenezer.ParquetLogging
 import au.com.cba.omnia.ebenezer.scrooge.hive._
@@ -36,8 +37,7 @@ import au.com.cba.omnia.maestro.core.thrift.scrooge.StringPair
 
 private object ViewExec extends ViewExecution
 
-object ViewExecutionSpec extends ThermometerSpec with HiveSupport with ParquetLogging { def is = s2"""
-
+object ViewExecutionSpec extends ThermometerHiveSpec with ParquetLogging { def is = s2"""
 View execution properties
 =========================
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/test/Arbitraries.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/test/Arbitraries.scala
@@ -12,17 +12,16 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package test
+package au.com.cba.omnia.maestro.core.test
 
-import au.com.cba.omnia.maestro.core.data._
-import au.com.cba.omnia.maestro.core.codec._
+import scalaz._, Scalaz._, \&/.These
 
-import scalaz._, Scalaz._, \&/._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
-import org.scalacheck._, Arbitrary._
 
+import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
+
+import au.com.cba.omnia.maestro.core.codec._
 
 object Arbitraries {
   implicit def ReasonArbitrary: Arbitrary[Reason] =

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/InputSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/InputSpec.scala
@@ -22,7 +22,7 @@ import java.io.File
 
 import org.joda.time.DateTime
 
-import scalaz._, Scalaz._
+import scalaz.{\/, -\/, \/-}
 
 import au.com.cba.omnia.omnitool.{Error, Ok}
 

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/IsolatedTest.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/upload/IsolatedTest.scala
@@ -12,8 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package upload
+package au.com.cba.omnia.maestro.core.upload
 
 import scala.util.Random
 
@@ -56,11 +55,13 @@ object isolatedTest extends Fixture[IsolatedDirs] {
   // WARNING: deleteAll will follow symlinks!
   // Java 7 supports symlinks, so once we drop Java 6 support we should be
   // able to do this properly, or use a library function that does it properly
-  def deleteAll(file: File) {
+  def deleteAll(file: File): Unit = {
     if (file.isDirectory)
       file.listFiles.foreach(deleteAll)
-    if (file.exists)
+    if (file.exists) {
       file.delete
+      ()
+    }
   }
 
   def apply[R: AsResult](test: IsolatedDirs => R) = {

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/validate/ValidatorSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/validate/ValidatorSpec.scala
@@ -12,10 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package au.com.cba.omnia.maestro.core
-package validate
-
-import scalaz._, Scalaz._
+package au.com.cba.omnia.maestro.core.validate
 
 import org.scalacheck.Arbitrary
 

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerJob.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerJob.scala
@@ -14,8 +14,6 @@
 
 package au.com.cba.omnia.maestro.example
 
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
-
 import com.twitter.scalding.{Config, Execution}
 
 import au.com.cba.omnia.ebenezer.scrooge.hive.Hive

--- a/maestro-example/src/test/resources/log4j.properties
+++ b/maestro-example/src/test/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.rootLogger=ERROR,console
+hadoop.root.logger=ERROR,console

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerExecutionSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerExecutionSpec.scala
@@ -14,8 +14,8 @@
 
 package au.com.cba.omnia.maestro.example
 
-import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
-import au.com.cba.omnia.thermometer.hive.HiveSupport
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.ParquetLogging
@@ -27,9 +27,8 @@ import au.com.cba.omnia.maestro.test.Records
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
 object CustomerExecutionSpec
-  extends ThermometerSpec
+  extends ThermometerHiveSpec
   with Records
-  with HiveSupport
   with ParquetLogging { def is = s2"""
 
 Customer Execution

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerJobSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerJobSpec.scala
@@ -14,8 +14,8 @@
 
 package au.com.cba.omnia.maestro.example
 
-import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
-import au.com.cba.omnia.thermometer.hive.HiveSupport
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.test.ParquetThermometerRecordReader
@@ -26,9 +26,8 @@ import au.com.cba.omnia.maestro.test.Records
 import au.com.cba.omnia.maestro.example.thrift.{Customer, Account}
 
 object CustomerJobSpec
-  extends ThermometerSpec
-  with Records
-  with HiveSupport { def is = s2"""
+  extends ThermometerHiveSpec
+  with Records { def is = s2"""
 
 Customer Job
 ============

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportJobSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportJobSpec.scala
@@ -81,6 +81,8 @@ CustomerSqoopExportJobSpec test
           sub_cat varchar(20),
           balance integer)
       """).execute.apply()
+
+      ()
     }
 
     def tableData(

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecutionSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportExecutionSpec.scala
@@ -18,8 +18,8 @@ import scalikejdbc.{SQL, AutoSession, ConnectionPool}
 
 import au.com.cba.omnia.parlour.SqoopSyntax.ParlourImportDsl
 
-import au.com.cba.omnia.thermometer.hive.HiveSupport
-import au.com.cba.omnia.thermometer.core.{ThermometerSpec, Thermometer}, Thermometer._
+import au.com.cba.omnia.thermometer.core.Thermometer._
+import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 import au.com.cba.omnia.thermometer.fact.PathFactoids._
 
 import au.com.cba.omnia.ebenezer.ParquetLogging
@@ -30,9 +30,8 @@ import au.com.cba.omnia.maestro.test.{Records, SqoopExecutionTest}
 import au.com.cba.omnia.maestro.example.thrift.Customer
 
 object CustomerSqoopImportExecutionSpec
-  extends ThermometerSpec
+  extends ThermometerHiveSpec
   with Records
-  with HiveSupport
   with ParquetLogging { def is = s2"""
 
 CustomerSqoopImportExecution test

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/DecodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/DecodeMacro.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 import com.twitter.scrooge._
 

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/EncodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/EncodeMacro.scala
@@ -30,7 +30,8 @@ object EncodeMacro {
     import c.universe._
     Inspect.ensureThriftType[A](c) 
 
-    val companion = weakTypeOf[A].typeSymbol.companionSymbol
+    val typ       = weakTypeOf[A]
+    val companion = typ.typeSymbol.companionSymbol
     val members   = Inspect.methods[A](c)
 
     def encode(xs: List[MethodSymbol]): List[Tree] = xs.map { x =>
@@ -39,6 +40,10 @@ object EncodeMacro {
 
     val fields = q"""List(..${encode(members)}).flatten"""
 
-    c.Expr[Encode[A]](q"Encode((none, a) => { $fields })")
+    val r = q"""
+       import au.com.cba.omnia.maestro.core.codec.Encode
+       Encode((none: String, a: $typ) => { $fields })
+    """
+    c.Expr[Encode[A]](r)
   }
 }

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/EncodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/EncodeMacro.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 import com.twitter.scrooge.ThriftStruct
 
@@ -31,7 +31,7 @@ object EncodeMacro {
     Inspect.ensureThriftType[A](c) 
 
     val typ       = weakTypeOf[A]
-    val companion = typ.typeSymbol.companionSymbol
+    val companion = typ.typeSymbol.companion
     val members   = Inspect.methods[A](c)
 
     def encode(xs: List[MethodSymbol]): List[Tree] = xs.map { x =>

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/FieldsMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/FieldsMacro.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 import scala.annotation.StaticAnnotation
 
 import com.twitter.scrooge.ThriftStruct
@@ -31,24 +31,24 @@ object FieldsMacro {
 
     val typ        = c.universe.weakTypeOf[A]
     val entries    = Inspect.fields[A](c)
-    val companion  = typ.typeSymbol.companionSymbol
-    val nameGetter = newTermName("name")
-    val idGetter   = newTermName("id")
+    val companion  = typ.typeSymbol.companion
+    val nameGetter = TermName("name")
+    val idGetter   = TermName("id")
     
     val fields = entries.map({
       case (method, field) =>
-        val term    = q"""$companion.${newTermName(field + "Field")}"""
+        val term    = q"""$companion.${TermName(field + "Field")}"""
         val srcName = q"""$term.$nameGetter"""
         val srcId   = q"""$term.$idGetter"""
 
         val get     = q"""au.com.cba.omnia.maestro.core.data.Accessor[${method.returnType}]($srcId)"""
         val fld     = q"""au.com.cba.omnia.maestro.core.data.Field[$typ, ${method.returnType}]($srcName,$get)"""
         
-        q"""val ${newTermName(field)} = $fld"""
+        q"""val ${TermName(field)} = $fld"""
     })
     val refs = entries.map({
       case (method, field) =>
-        val n = newTermName(field)
+        val n = TermName(field)
         q"$n"
     })
     val r =q"class FieldsWrapper { ..$fields; def AllFields = List(..$refs) }; new FieldsWrapper {}"

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/FieldsMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/FieldsMacro.scala
@@ -14,12 +14,10 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import au.com.cba.omnia.maestro.core.codec._
-import au.com.cba.omnia.maestro.core.data._
-import com.twitter.scrooge._
-
 import scala.reflect.macros.Context
 import scala.annotation.StaticAnnotation
+
+import com.twitter.scrooge.ThriftStruct
 
 class body(tree: Any) extends StaticAnnotation
 

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/HumbugDecodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/HumbugDecodeMacro.scala
@@ -93,7 +93,7 @@ object HumbugDecodeMacro {
 
     def decodeUnknownSource(xs: List[(MethodSymbol, Int)]) = q"""
       if (source.length < $size) {
-        DecodeError(source, position, NotEnoughInput($size, $typeName))
+        DecodeError[(List[String], Int, $typ)](source, position, NotEnoughInput($size, $typeName))
       } else {
         val fields = source.take($size).toArray
         var index  = -1
@@ -103,7 +103,7 @@ object HumbugDecodeMacro {
           ..${decodeUnknowns(xs)}
           DecodeOk((source.drop($size), position + $size, struct))
         } catch {
-          case NonFatal(e) => DecodeError(
+          case NonFatal(e) => DecodeError[(List[String], Int, $typ)](
             source.drop(index - position),
             position + index,
             ParseError(fields(index), tag, That(e))

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Inspect.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Inspect.scala
@@ -16,9 +16,7 @@ package au.com.cba.omnia.maestro.macros
 
 import scala.reflect.macros.Context
 
-import com.twitter.scrooge._
-
-import au.com.cba.omnia.maestro.core.codec._
+import com.twitter.scrooge.ThriftStruct
 
 import au.com.cba.omnia.humbug.HumbugThriftStruct
 

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Inspect.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Inspect.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 import com.twitter.scrooge.ThriftStruct
 
@@ -29,7 +29,6 @@ object Inspect {
 
   /** Same as indexed but for any type where the type is assumed to be ThriftStruct.*/
   def indexedUnsafe(c: Context)(typ: c.universe.Type): List[(c.universe.MethodSymbol, Int)] = {
-    import c.universe._
     typ.members.toList.map(member => (member, member.name.toString)).collect({
       case (member, ProductField(n)) =>
         (member.asMethod, n.toInt)
@@ -58,12 +57,12 @@ object Inspect {
     val fields =
       if (typ <:< c.universe.weakTypeOf[HumbugThriftStruct]) {
         // Get the fields in declaration order
-        typ.declarations.sorted.toList.collect {
+        typ.decls.sorted.toList.collect {
           case sym: TermSymbol if sym.isVar => sym.name.toString.trim.capitalize
         }
       } else
-        typ.typeSymbol.companionSymbol.typeSignature
-          .member(newTermName("apply")).asMethod.paramss.head.map(_.name.toString.capitalize)
+        typ.typeSymbol.companion.typeSignature
+          .member(TermName("apply")).asMethod.paramLists.head.map(_.name.toString.capitalize)
 
     methodsUnsafe(c)(typ).zip(fields)
   }

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/MacroUtils.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/MacroUtils.scala
@@ -14,8 +14,8 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
-import scala.util.{Failure, Success}
+import scala.reflect.macros.whitebox.Context
+import scala.util.{Try, Failure, Success}
 
 object MacroUtils {
   /** Returns `Some(t)` iff `o` is `Option[T]` else returns `None`. */
@@ -43,15 +43,15 @@ object MacroUtils {
   def compileErrors(code: String): Option[String] = macro compileErrorsImpl
 
   def compileErrorsImpl(c:Context)(code: c.Expr[String]):c.Expr[Option[String]] = {
-    import c.universe._
+    import c.universe.{Try => _, _}
 
     val Expr(Literal(Constant(codeStr: String))) = code
-    val attemptToTypecheck = scala.util.Try(c.typeCheck(c.parse(s"{ val ${newTermName(c.fresh)} = { $codeStr } }")))
+    val attemptToTypecheck = Try(c.typecheck(c.parse(s"{ val ${TermName(c.freshName)} = { $codeStr } }")))
 
 
-    val errors:Option[String] = attemptToTypecheck match {
+    val errors: Option[String] = attemptToTypecheck match {
       case Failure(e) => Some(e.getMessage)
-      case _          => None
+      case Success(_) => None
     }
     c.Expr[Option[String]](q"${errors}")
   }

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacro.scala
@@ -83,7 +83,7 @@ object ScroogeDecodeMacro {
 
     def decodeUnknownSource(xs: List[(MethodSymbol, Int)]) = q"""
       if (source.length < $size) {
-        DecodeError(source, position, NotEnoughInput($size, $typeName))
+        DecodeError[(List[String], Int, $typ)](source, position, NotEnoughInput($size, $typeName))
       } else {
         val fields = source.take($size).toArray
         var index  = -1
@@ -92,7 +92,7 @@ object ScroogeDecodeMacro {
           val result = ${build(decodeUnknowns(xs))}
           DecodeOk((source.drop($size), position + $size, result))
         } catch {
-          case NonFatal(e) => DecodeError(
+          case NonFatal(e) => DecodeError[(List[String], Int, $typ)](
             source.drop(index - position),
             position + index,
             ParseError(fields(index), tag, That(e))

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacro.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 import com.twitter.scrooge.ThriftStruct
 
@@ -77,7 +77,7 @@ object ScroogeDecodeMacro {
 
     val typ       = weakTypeOf[A]
     val typeName  = typ.toString
-    val companion = typ.typeSymbol.companionSymbol
+    val companion = typ.typeSymbol.companion
     val members   = Inspect.indexed[A](c)
     val size      = members.length
 
@@ -101,7 +101,7 @@ object ScroogeDecodeMacro {
       }
     """
 
-    def build(args: List[Tree]) = Apply(Select(Ident(companion), newTermName("apply")), args)
+    def build(args: List[Tree]) = Apply(Select(Ident(companion), TermName("apply")), args)
 
     def decodeUnknowns(xs: List[(MethodSymbol, Int)]): List[Tree] = xs.map { case (x, i) =>
       val index = i - 1
@@ -112,7 +112,7 @@ object ScroogeDecodeMacro {
             else                        Option(fields($index))
           """
         else {
-          val method = newTermName("to" + param)
+          val method = TermName("to" + param)
           val tag    = s"Option[$param]"
           q"""{
             tag   = $tag
@@ -126,7 +126,7 @@ object ScroogeDecodeMacro {
       } getOrElse {
         if (x.returnType == stringType) q"fields($index)"
         else {
-          val method = newTermName("to" + x.returnType)
+          val method = TermName("to" + x.returnType)
           val tag    = x.returnType.toString
           q"""{
             tag   = $tag

--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/TagMacro.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/TagMacro.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.macros
 
-import scala.reflect.macros.Context
+import scala.reflect.macros.whitebox.Context
 
 import com.twitter.scrooge.ThriftStruct
 

--- a/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/EncodeMacroSpec.scala
+++ b/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/EncodeMacroSpec.scala
@@ -31,10 +31,10 @@ EncodeMacro
 
 """
 
-  implicit val encode = Macros.mkEncode[Types]
+  implicit val encode: Encode[Types] = Macros.mkEncode[Types]
 
   def test = prop { (x: Types) =>
-    val none = "\0"
+    val none = "\u0000"
     val y = x.copy(optStringField = x.optStringField.map(a => if (a == none) "other" else a))
 
     val expected = List(

--- a/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/HumbugDecodeMacroSpec.scala
+++ b/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/HumbugDecodeMacroSpec.scala
@@ -38,7 +38,7 @@ HumbugDecodeMacro
   implicit val encodeLarge = Macros.mkEncode[Large]
   implicit val decodeLarge = Macros.mkDecode[Large]
 
-  val noneVal = "\0"
+  val noneVal = "\u0000"
 
   def decode = prop { (types: Types) =>
     decodeTypes.decode(noneVal, Encode.encode(noneVal, types)) must_== DecodeOk(types)

--- a/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacroSpec.scala
+++ b/maestro-macros/src/test/scala/au/com/cba/omnia/maestro/macros/ScroogeDecodeMacroSpec.scala
@@ -35,7 +35,7 @@ ScroogeDecodeMacro
   implicit val encodeTypes = Macros.mkEncode[Types]
   implicit val decodeTypes = Macros.mkDecode[Types]
 
-  val noneVal = "\0"
+  val noneVal = "\u0000"
 
   def decode = prop { (types: Types) =>
     decodeTypes.decode(noneVal, Encode.encode(noneVal, types)) must_== DecodeOk(types)

--- a/maestro-test/src/main/scala/au/com/cba/omnia/maestro/test/Arbitraries.scala
+++ b/maestro-test/src/main/scala/au/com/cba/omnia/maestro/test/Arbitraries.scala
@@ -14,7 +14,7 @@
 
 package au.com.cba.omnia.maestro.test
 
-import scalaz._, Scalaz._, \&/._
+import scalaz._, Scalaz._
 
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/build.scala
+++ b/project/build.scala
@@ -133,8 +133,6 @@ object build extends Build {
             exclude("org.scala-lang.modules", "scala-parser-combinators_2.11")
             exclude("org.scala-lang.modules", "scala-xml_2.11")
          , "org.scala-lang"   % "scala-reflect"  % sv
-         , "com.twitter"     %% "util-eval"      % "6.24.0" % "test"
-            exclude("com.twitter", "util-core_2.11")
          ) ++ depend.testing())
        , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
     )

--- a/project/build.scala
+++ b/project/build.scala
@@ -52,7 +52,11 @@ object build extends Build {
     strictDependencySettings ++
     uniform.docSettings("https://github.com/CommBank/maestro") ++
     Seq(
-      logLevel in assembly := Level.Error
+      logLevel in assembly := Level.Error,
+      // Run tests sequentially across the subprojects.
+      concurrentRestrictions in Global := Seq(
+        Tags.limit(Tags.Test, 1)
+      )
     )
 
   lazy val all = Project(

--- a/project/build.scala
+++ b/project/build.scala
@@ -53,6 +53,7 @@ object build extends Build {
     uniform.docSettings("https://github.com/CommBank/maestro") ++
     Seq(
       logLevel in assembly := Level.Error,
+      updateOptions := updateOptions.value.withCachedResolution(true),
       // Run tests sequentially across the subprojects.
       concurrentRestrictions in Global := Seq(
         Tags.limit(Tags.Test, 1)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,7 +17,7 @@ resolvers ++= Seq(
   "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local"
 )
 
-val uniformVersion = "1.0.0-20150325230450-5af497f"
+val uniformVersion = "1.2.4-20150513065051-9b4cf64"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
@@ -27,4 +27,4 @@ addSbtPlugin("au.com.cba.omnia" % "uniform-thrift"     % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
 
-addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.5.1-20150326040350-55bca1b")
+addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.6.1-20150513010955-5eb6297")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.10.2"
+version in ThisBuild := "2.11.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
* Upgrades to Scala 2.11 and Scalding 0.13.1
* Fixes all the warnings, in particular deprecation warnings (except for schema sub project). This closes #170.
* Closes #300 by reverting #301.
* Enables cached dependency resolution
* Sets up the tests to be run sequentially
* Removes the Eval tests from JoinMacroSpec in favour of the functionality @triggerNZ added to MacroUtils.
* Fixes some style issues.
