### PR TITLE
Adding a timeout for fetching job counters

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroJob.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/scalding/MaestroJob.scala
@@ -18,7 +18,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.control.NonFatal
 
-import com.twitter.scalding.{Config, Execution, ExecutionApp}
+import com.twitter.scalding.{Config, Mode, Execution, ExecutionApp}
 
 /** An enumeration representing possible program status */
 sealed trait JobStatus {
@@ -103,6 +103,13 @@ trait MaestroJob extends Serializable {
   }
 
   private object ExApp extends ExecutionApp {
+    val CounterTimeoutConfig = ("cascading.step.counter.timeout", "60") //Sufficiently large
+    
     def job = null // never used
+
+    override def config(inputArgs: Array[String]): (Config, Mode) = {
+      val (config, mode) = super.config(inputArgs)
+      (config + CounterTimeoutConfig, mode)
+    }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.10.1"
+version in ThisBuild := "2.10.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
The timeout value is set to 60 seconds which seems sufficiently high but I am happy to change it.