### PR TITLE
Fix schema compile warnings

### DIFF
--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Classifier.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Classifier.scala
@@ -13,11 +13,9 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import  au.com.cba.omnia.maestro.schema.syntax._
-
 
 /** A wrapper for raw syntaxes, and topes with their syntax. */
-sealed trait Classifier { 
+sealed trait Classifier {
   /** Human readable name for the Classifier. */
   def name: String
 
@@ -30,12 +28,12 @@ sealed trait Classifier {
    *  classifier. */
   def likeness(s: String): Double
 
-  /** Check if this string completely matches the classifier, 
+  /** Check if this string completely matches the classifier,
    *  meaning the likeness is 1.0 */
   def matches(s: String): Boolean =
     likeness(s) >= 1.0
 
-  /** Yield the parent syntaxes of this classifier, if there are any. 
+  /** Yield the parent syntaxes of this classifier, if there are any.
    *  If a string matches this syntax, then it also matches all the parents. */
   def parents: Set[Syntax]
 }
@@ -43,7 +41,7 @@ sealed trait Classifier {
 
 /** Wrap a Syntax as a Classifier. */
 case class ClasSyntax(syntax: Syntax)
-  extends Classifier { 
+  extends Classifier {
 
   val name: String =
     syntax.name
@@ -80,7 +78,7 @@ case class ClasTope(tope: Tope, syntax: Syntax)
 /** Companion object for Classifiers. */
 object Classifier {
 
-  /** Yield an array of all classifiers we know about. 
+  /** Yield an array of all classifiers we know about.
    *  We keep classifier counts in an array to ensure they are stored unboxed at
    *  runtime. The classifiers themselves are also stored in an array so we can
    *  just map arrays to arrays when performing the count. */
@@ -88,7 +86,7 @@ object Classifier {
 
     // Classifiers that wrap raw syntaxes.
     def sx: Array[Classifier] =
-      Syntaxes.syntaxes     
+      Syntaxes.syntaxes
         .map { s => ClasSyntax(s) }.toArray
 
     // Classifiers that wrap topes.
@@ -99,4 +97,3 @@ object Classifier {
     sx ++ st
   }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Infer.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Infer.scala
@@ -13,15 +13,13 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema._
 import au.com.cba.omnia.maestro.schema.syntax._
-import au.com.cba.omnia.maestro.schema.tope._
 
 
 /** Top-level of the schema inferencer. */
 object Infer {
 
-  /** Given a squashed histogram for a column, 
+  /** Given a squashed histogram for a column,
    *  try to infer a suitable format / semantic type for it. */
   def infer(hist: Histogram): Option[Format] = {
 
@@ -53,4 +51,3 @@ object Infer {
     else None
   }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Schema.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Schema.scala
@@ -13,11 +13,6 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.syntax._
-import au.com.cba.omnia.maestro.schema.pretty._
-
-
 /** Companion object for Schemas. */
 object Schema {
 
@@ -40,4 +35,3 @@ object Schema {
     : String =
     Histogram(Classifier.all .zip (counts) .toMap).pretty
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Tope.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/Tope.scala
@@ -13,7 +13,6 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema._
 import au.com.cba.omnia.maestro.schema.tope._
 
 
@@ -61,4 +60,3 @@ object Topes {
   val namesSyntaxes: Array[String] =
     topes .flatMap { _.names }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/commands/Infer.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/commands/Infer.scala
@@ -15,7 +15,7 @@ package au.com.cba.omnia.maestro.schema
 package commands
 
 import scala.io.Source
-import scala.collection._
+import scala.util.parsing.json.{JSON}
 
 import com.quantifind.sumac.ArgMain
 import com.quantifind.sumac.validation._
@@ -25,7 +25,6 @@ import au.com.cba.omnia.maestro.schema
 import au.com.cba.omnia.maestro.schema._
 import au.com.cba.omnia.maestro.schema.pretty._
 import au.com.cba.omnia.maestro.schema.taste.{Load => TasteLoad}
-import scala.util.parsing.json.{JSON}
 
 
 /** Arguments for `Infer` command. .*/
@@ -38,10 +37,10 @@ class InferArgs extends FieldArgs {
   @Required var table: String = _
 
   /** File containing names and storage types of columns.
-   *  Each line is treated as a description of a single column, 
-   *  where the first  word is the column name, 
+   *  Each line is treated as a description of a single column,
+   *  where the first  word is the column name,
    *  and   the second word is the hive storage type.
-   * 
+   *
    *  Example:
    *    paty_i   string
    *    acct_i   string
@@ -64,21 +63,21 @@ object Infer extends ArgMain[InferArgs]
     val taste = TasteLoad.loadNamesTaste(args.names, args.taste)
     val names = taste .map { _._1 }
     val hists = taste .map { _._2 } .map { h => schema.Squash.squash(h) }
-        
+
     // Infer specs for all the columns.
-    val colSpecs = 
+    val colSpecs =
       names .zip (hists)
-        .map { case (name, hist) => 
-            ColumnSpec( 
-              name, 
-              hive.HiveType.HiveString, 
-              schema.Infer.infer(hist), 
+        .map { case (name, hist) =>
+            ColumnSpec(
+              name,
+              hive.HiveType.HiveString,
+              schema.Infer.infer(hist),
               hist,
               "") }
 
     // Build the overall spec for the table.
     val tableSpec: TableSpec =
-      TableSpec( 
+      TableSpec(
         args.database,
         args.table,
         List(),
@@ -86,6 +85,5 @@ object Infer extends ArgMain[InferArgs]
 
     // Print the JSONified table spec to console.
     println(JsonDoc.render(0, tableSpec.toJson))
-  }  
+  }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/jobs/Check.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/jobs/Check.scala
@@ -15,17 +15,18 @@ package au.com.cba.omnia.maestro.schema
 package jobs
 
 import scala.io.Source
-import org.apache.hadoop.fs._
+
 import org.apache.commons.lang.StringEscapeUtils._
-import com.twitter.scalding._, Dsl._, TDsl._
+
+import com.twitter.scalding._
 
 import au.com.cba.omnia.maestro.schema._
 import au.com.cba.omnia.maestro.schema.hive.Input
 
 
-/** Job to check a table against an existing schema. 
+/** Job to check a table against an existing schema.
  *  Rows that do not match the schema get written to the given errors file. */
-class Check(args: Args) 
+class Check(args: Args)
   extends Job(args) {
 
   // Local file containing schema to check against.
@@ -43,7 +44,7 @@ class Check(args: Args)
   val pipeOutDiag    = TypedTsv[String](args("out-hdfs-diag"))
 
   // Load column names and formats from the schema definition.
-  val columnDefs: List[Check.ColumnDef] = 
+  val columnDefs: List[Check.ColumnDef] =
     Load.loadFormats(fileSchema)
 
 
@@ -67,14 +68,14 @@ class Check(args: Args)
 object Check {
 
   /** A column name along with its format. */
-  type ColumnDef 
+  type ColumnDef
     = (String, Option[Format])
 
 
   /** Check if a row matches the associated table spec.
    *  Returns the column specs and field values that don't match.
    *
-   *  If the number of fields does not match the number of columns then we 
+   *  If the number of fields does not match the number of columns then we
    *  get the result for the shorter of the two. */
   def slurpErrorFields(s: String, sep: Char, columnDefs: List[ColumnDef])
     : List[(ColumnDef, String)] =
@@ -84,7 +85,7 @@ object Check {
       .toList
 
 
-  /** Check if a row matches its associated list of ColumnDefs. 
+  /** Check if a row matches its associated list of ColumnDefs.
    *
    *  If the number of fields does not match the number of columns then we
    *  get the result for the shorter of the two. */
@@ -100,7 +101,7 @@ object Check {
     : Boolean =
     columnDef._2 match {
       case None         => true
-      case Some(format) => format.matches(s) 
+      case Some(format) => format.matches(s)
     }
 
 
@@ -110,7 +111,7 @@ object Check {
     : Option[(ColumnDef, String)] =
     columnDef._2 match {
       case None          => None
-      case Some(format)  => 
+      case Some(format)  =>
         if (format.matches(s))
               None
         else  Some((columnDef, s)) }
@@ -118,26 +119,25 @@ object Check {
 
 
 object Pretty {
-  
+
   /** Pretty print an optional format, showing '-' for the None case. */
-  def prettyOptionFormat(op: Option[Format]): String = 
-    op match { 
+  def prettyOptionFormat(op: Option[Format]): String =
+    op match {
         case None    => "-"
-        case Some(f) => f.pretty 
+        case Some(f) => f.pretty
     }
 
 
   /** Pretty print a sequence of check errors. */
-  def prettyDiag(errors: Seq[(Check.ColumnDef, String)]): String = 
+  def prettyDiag(errors: Seq[(Check.ColumnDef, String)]): String =
     errors
       .map { case (columnDef, s) =>
-        columnDef._1 ++ 
-        "("       ++ 
-        "\"" ++ escapeJava(s) ++ "\"" ++ 
-        " : "     ++ 
-        prettyOptionFormat(columnDef._2) ++ 
-        ")" 
+        columnDef._1 ++
+        "("       ++
+        "\"" ++ escapeJava(s) ++ "\"" ++
+        " : "     ++
+        prettyOptionFormat(columnDef._2) ++
+        ")"
        }
       .mkString("; ")
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/ColumnSpec.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/ColumnSpec.scala
@@ -14,7 +14,6 @@
 package au.com.cba.omnia.maestro.schema
 
 import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.syntax._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
@@ -37,24 +36,24 @@ case class ColumnSpec(
   def matches(s: String): Boolean =
     format match {
       case None     => true
-      case Some(f)  => f.matches(s) 
+      case Some(f)  => f.matches(s)
     }
 
 
   /** Pretty print the ColumnSpec as a String. */
-  def pretty: String = 
-    f"$name%-25s"               + " | "  + 
-    HiveType.pretty(hivetype)   + " | "  + 
-    prettyOptionFormat(format)  + "\n"   + 
-    " " * 25                    + " | "  + 
+  def pretty: String =
+    f"$name%-25s"               + " | "  +
+    HiveType.pretty(hivetype)   + " | "  +
+    prettyOptionFormat(format)  + "\n"   +
+    " " * 25                    + " | "  +
     histogram.pretty + ";\n"
 
 
   /** Pretty print a Format as String, or '-' for a missing format. */
-  def prettyOptionFormat(of: Option[Format]): String = 
-    of match { 
+  def prettyOptionFormat(of: Option[Format]): String =
+    of match {
       case None     => "-"
-      case Some(f)  => f.pretty 
+      case Some(f)  => f.pretty
     }
 
 
@@ -73,4 +72,3 @@ case class ColumnSpec(
     JsonMap(fields, true)
   }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Format.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Format.scala
@@ -13,8 +13,6 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.syntax._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
@@ -24,16 +22,16 @@ import au.com.cba.omnia.maestro.schema.pretty._
 case class Format(list: List[Classifier]) {
 
   /** Append two formats. */
-  def ++(that: Format): Format = 
+  def ++(that: Format): Format =
     Format(this.list ++ that.list)
 
   /** Check if this string matches any of the classifiers in the Format. */
-  def matches(s: String): Boolean = 
+  def matches(s: String): Boolean =
     list.exists(_.matches(s))
 
   /** Pretty print a Format as a string. */
   def pretty: String =
-    list 
+    list
       .map {_.name}
       .mkString (" + ")
 
@@ -41,4 +39,3 @@ case class Format(list: List[Classifier]) {
   def toJson: JsonDoc =
     JsonString(pretty)
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Histogram.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Histogram.scala
@@ -13,12 +13,10 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.syntax._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
-/** Histogram of how many values in a column match each Classifier 
+/** Histogram of how many values in a column match each Classifier
  *
  *  @param counts How many values match each classifier.
  */
@@ -46,7 +44,7 @@ case class Histogram(counts: Map[Classifier, Int]) {
 
   /** Extract the histogram with the classifiers in the standard sorted
       order. Don't return classifiers with zero counts. */
-  def sorted: List[(Classifier, Int)] = 
+  def sorted: List[(Classifier, Int)] =
     counts
       .toList
 

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Load.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/Load.scala
@@ -18,14 +18,9 @@ import scala.io.Source
 
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.{NoPosition, Position, Reader}
-
-import au.com.cba.omnia.maestro.schema._
-import au.com.cba.omnia.maestro.schema.syntax._
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.hive.HiveType._
-import au.com.cba.omnia.maestro.schema.SchemaParser._
-
 import scala.util.parsing.json.{JSON}
+
+import au.com.cba.omnia.maestro.schema.SchemaParser._
 
 
 object Load {
@@ -45,7 +40,7 @@ object Load {
         .getLines .mkString ("\n")
 
     // Do initial JSON parsing of schema file.
-    val jsonSchema: JsonSchema = 
+    val jsonSchema: JsonSchema =
       JSON.parseFull(strSchema)
           .getOrElse { throw new Exception("Cannot parse schema file as JSON.") }
           .asInstanceOf[JsonSchema]
@@ -55,7 +50,7 @@ object Load {
       (for {
         cols  <- jsonSchema.get("columns")
         name  <- sequence(cols.map { col =>
-            for { nm <- col.get("name") } 
+            for { nm <- col.get("name") }
             yield nm.asInstanceOf[String] })
       } yield name)
       .getOrElse (throw new Exception("Cannot parse names from JSON schema."))
@@ -65,7 +60,7 @@ object Load {
       (for {
         cols  <- jsonSchema.get("columns")
         name  <- sequence(cols.map { col =>
-            for { nm <- col.get("format") } 
+            for { nm <- col.get("format") }
             yield nm.asInstanceOf[String] })
       } yield name)
       .getOrElse (throw new Exception("Cannot parse formats from JSON schema."))
@@ -93,5 +88,5 @@ object Load {
 
   /** Missing Haskell-esque sequence function. */
   def sequence[A](a: List[Option[A]]): Option[List[A]] =
-    a.foldRight[Option[List[A]]](Some(Nil))((x,y) => map2(x,y)(_ :: _)) 
+    a.foldRight[Option[List[A]]](Some(Nil))((x,y) => map2(x,y)(_ :: _))
 }

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/TableSpec.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/schema/TableSpec.scala
@@ -13,8 +13,6 @@
 //   limitations under the License.
 package au.com.cba.omnia.maestro.schema
 
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.syntax._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
@@ -44,4 +42,3 @@ case class TableSpec(
       ("columns",   JsonList(columnSpecs.map { _.toJson }, true))),
       true)
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Load.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Load.scala
@@ -19,15 +19,9 @@ import scala.io.Source
 
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.{NoPosition, Position, Reader}
-
-import au.com.cba.omnia.maestro.schema._
-import au.com.cba.omnia.maestro.schema.syntax._
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.hive.HiveType._
-import au.com.cba.omnia.maestro.schema.SchemaParser._
-
 import scala.util.parsing.json.{JSON}
 
+import au.com.cba.omnia.maestro.schema._
 
 object Load {
 
@@ -40,7 +34,7 @@ object Load {
   /** Load histograms from JSON taste file at the given path.
    *  Also load names from a names file if we have one. */
   def loadNamesTaste(
-      fileNames: Option[String], 
+      fileNames: Option[String],
       fileTaste: String)
     : (List[(String, Histogram)]) = {
 
@@ -50,7 +44,7 @@ object Load {
         .getLines .mkString ("\n")
 
     // Do initial JSON parsing of taste file.
-    val jsonTaste: JsonTaste = 
+    val jsonTaste: JsonTaste =
       JSON.parseFull(strTaste)
           .getOrElse { throw new Exception("Cannot parse taste file as JSON.") }
           .asInstanceOf[JsonTaste]
@@ -60,7 +54,7 @@ object Load {
       (for {
         rows  <- jsonTaste.get("columns")
         name  <- sequence(rows.map { row =>
-            for { nm <- row.get("name") } 
+            for { nm <- row.get("name") }
             yield nm.asInstanceOf[String] })
       } yield name)
 
@@ -68,7 +62,7 @@ object Load {
     val namesExt: Option[List[String]] =
       fileNames.map { file =>
         sequence(Source.fromFile(file)
-          .getLines 
+          .getLines
           .map       { w  => w  .split("\\s+").toList }
           .map       { ws => ws .lift (0) }
           .toList)
@@ -76,12 +70,12 @@ object Load {
         }
 
     // Decide where the names come from.
-    val names: List[String] = 
+    val names: List[String] =
       namesExt match {
         case Some(names)   => names
         case None          => namesTaste match {
           case Some(names) => names
-          case None        => 
+          case None        =>
             throw new Exception(
               "No column names in taste file.\n" +
               "and an external names file was not provided.")
@@ -93,14 +87,14 @@ object Load {
     val histsRaw: List[List[(String, Int)]] =
       (for {
         rows  <- jsonTaste.get("columns")
-        clas  <- sequence(rows.map { row => 
-          for { cl <- row.get("classifiers") } 
+        clas  <- sequence(rows.map { row =>
+          for { cl <- row.get("classifiers") }
           yield cl.asInstanceOf[Map[String,_]] })
        } yield clas)
       .getOrElse { throw new Exception("Cannot parse classifiers. ") }
 
       // Truncate incoming classifier counts to integers.
-      .map ( m => m.toList.map { case (s, d) => 
+      .map ( m => m.toList.map { case (s, d) =>
         (s, d.asInstanceOf[Double].toInt) })
 
     // Parse the classifier strings and produce a real histogram for each row.
@@ -115,8 +109,8 @@ object Load {
 
   /** Load a Histogram from the raw JSON. */
   def parseHistogram(counts: List[(String, Int)]): Histogram = {
-    val clas  = 
-      counts.map { case (s, d) => 
+    val clas  =
+      counts.map { case (s, d) =>
         SchemaParser.parseString(SchemaParser.pClassifier, s) match {
           case Left(err) => throw new Exception("Cannot parse classifier: " + s)
           case Right(c)  => (c, d)
@@ -133,6 +127,5 @@ object Load {
 
   /** Missing Haskell-esque sequence function. */
   def sequence[A](a: List[Option[A]]): Option[List[A]] =
-    a.foldRight[Option[List[A]]](Some(Nil))((x,y) => map2(x,y)(_ :: _)) 
+    a.foldRight[Option[List[A]]](Some(Nil))((x,y) => map2(x,y)(_ :: _))
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Parser.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Parser.scala
@@ -15,26 +15,12 @@
 package au.com.cba.omnia.maestro.schema
 package taste
 
-import scala.io.Source
-
-import scala.util.parsing.combinator.Parsers
-import scala.util.parsing.input.{NoPosition, Position, Reader}
-
 import au.com.cba.omnia.maestro.schema._
-import au.com.cba.omnia.maestro.schema.syntax._
-import au.com.cba.omnia.maestro.schema.hive._
-import au.com.cba.omnia.maestro.schema.hive.HiveType._
-import au.com.cba.omnia.maestro.schema.SchemaParser._
-
-import scala.util.parsing.json.{JSON}
-
 
 /** Parser for taste files. */
 object Parser {
   /** Parse a taste file from the user friendly non-JSON format. */
-  def apply(input: String): Either[SchemaParser.NoSuccess, Seq[Histogram]] = 
+  def apply(input: String): Either[SchemaParser.NoSuccess, Seq[Histogram]] =
     SchemaParser.parseString(SchemaParser.pTaste, input)
 
 }
-
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Row.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Row.scala
@@ -14,7 +14,6 @@
 package au.com.cba.omnia.maestro.schema
 package taste
 
-import au.com.cba.omnia.maestro.schema.taste._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
@@ -26,9 +25,9 @@ case class Row(
    * types if we have them. */
   def toJson(
     fieldNames:   Option[List[String]],
-    storageTypes: Option[List[String]]): JsonDoc = 
+    storageTypes: Option[List[String]]): JsonDoc =
     JsonList(
-      fieldTastes.toList.zipWithIndex.map { case (ft: Field, ix: Int) => 
+      fieldTastes.toList.zipWithIndex.map { case (ft: Field, ix: Int) =>
         ft.toJson(fieldNames.map(_(ix)), storageTypes.map(_(ix))) },
       true)
 }
@@ -39,8 +38,8 @@ object Row {
   /** Create a new, empty RowTaste. */
   def empty(maxHistSize: Int, fieldNum: Int): Row = {
 
-    val fieldTastes: Array[Field] = 
-      (for  { i <- 0 to fieldNum - 1 } 
+    val fieldTastes: Array[Field] =
+      (for  { i <- 0 to fieldNum - 1 }
        yield Field.empty(maxHistSize))
         .toArray
 
@@ -57,7 +56,7 @@ object Row {
    *  If the number of fields is different than the existing RowTaste
    *  then do nothing  */
   def accumulate(rt: Row, strs: Array[String]): Unit = {
-    if (rt.fieldTastes.length != strs.length) 
+    if (rt.fieldTastes.length != strs.length)
       ()
     else for (f <- 0 to strs.length - 1) {
       Field.accumulate(rt.fieldTastes(f), strs(f))
@@ -75,4 +74,3 @@ object Row {
     Row(fieldTastesX)
   }
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Sample.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Sample.scala
@@ -39,7 +39,7 @@ case class Sample(
   /** Pretty print the sample histogram.
    *  We print it sorted, so the most frequently occurring strings are listed
    *  first */
-  def toJsonHistogram: JsonDoc = 
+  def toJsonHistogram: JsonDoc =
     JsonMap(
       histogram
         .toList
@@ -61,12 +61,18 @@ object Sample {
 
     // If there is already an entry in the map for this string then
     // we can increment that.
-    if (smap.histogram.isDefinedAt(str))
-      smap.histogram  += ((str, smap.histogram(str) + 1))
+    if (smap.histogram.isDefinedAt(str)) {
+      // assigning to m suppresses a Scala warning: "discarded non-Unit value"
+      //  the map is mutable, so we don't need the new reference to it
+      val m = smap.histogram += ((str, smap.histogram(str) + 1))
+    }
 
     // If there is still space in the map then add a new entry.
-    else if (smap.histogram.size < smap.maxSize - 1)
-      smap.histogram  += ((str, 1))
+    else if (smap.histogram.size < smap.maxSize - 1) {
+      // assigning to m suppresses a Scala warning: "discarded non-Unit value"
+      //  the map is mutable, so we don't need the new reference to it
+      val m = smap.histogram += ((str, 1))
+    }
 
     // Otherwise remember that we had to spill this string.
     else
@@ -101,4 +107,3 @@ object Sample {
   }
 
 }
-

--- a/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Table.scala
+++ b/maestro-schema/src/main/scala/au/com/cba/omnia/maestro/schema/taste/Table.scala
@@ -17,7 +17,6 @@ package taste
 import scala.collection._
 
 import au.com.cba.omnia.maestro.schema._
-import au.com.cba.omnia.maestro.schema.taste._
 import au.com.cba.omnia.maestro.schema.pretty._
 
 
@@ -46,7 +45,7 @@ case class Table(
           storageTypes.get(rt.fieldTastes.length)
 
         ("columns", rt.toJson(oNames, oStorage))
-      }}, 
+      }},
       true)
 }
 
@@ -96,7 +95,7 @@ object Table {
 
 
   /** Get all the possible classifications for a given field. */
-  def classifyField(s: String): Array[Int] = 
+  def classifyField(s: String): Array[Int] =
     Classifier.all
       .map {_.likeness(s)}
       .map {like => if (like >= 1.0) 1 else 0}
@@ -105,7 +104,7 @@ object Table {
   /** Combine the information in two TableTastes to produce a new one. */
   def combine(tt1: Table, tt2: Table): Table = {
 
-    val tt3: Table = 
+    val tt3: Table =
       empty(tt1.maxHistSize)
 
     for ((num, rt1) <- tt1.rowTastes) {

--- a/project/build.scala
+++ b/project/build.scala
@@ -174,9 +174,10 @@ object build extends Build {
     ++ uniformAssemblySettings
     ++ Seq[Sett](
           libraryDependencies <++= scalaVersion.apply(sv => Seq(
-            "com.quantifind"     %% "sumac"         % "0.3.0"
-          , "org.scala-lang"     %  "scala-reflect" % sv
-          , "org.apache.commons" %  "commons-lang3" % "3.1"
+            "com.quantifind"         %% "sumac"                    % "0.3.0"
+          , "org.scala-lang"         %  "scala-reflect"            % sv
+          , "org.apache.commons"     %  "commons-lang3"            % "3.1"
+          , "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
           ) ++ depend.scalding() ++ depend.hadoopClasspath ++ depend.hadoop())
        )
     )


### PR DESCRIPTION
The update to Scala 2.11 caused some warnings in the schema project compilation. These related to:
  - unused imports,
  - one "discarded non-Unit value" due to changing a mutable map, and
  - deprecation of the Scala parser combinators from the core library.

This PR removes those warnings.