### PR TITLE
Ebenezer version bump

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -35,7 +35,7 @@ object build extends Build {
   type Sett = Def.Setting[_]
 
   val thermometerVersion = "1.0.0-20150513002558-a6bcf7f"
-  val ebenezerVersion    = "0.18.1-20150602022504-3af467a"
+  val ebenezerVersion    = "0.18.3-20150630045019-50d44ae"
   val omnitoolVersion    = "1.10.0-20150430044321-3ca9118"
   val permafrostVersion  = "0.10.0-20150615051457-13dbbaa"
   val edgeVersion        = "3.4.0-20150513004502-4b6d30d"


### PR DESCRIPTION
This allows ETL projects to use modified `setupHiveTestTable` function so that user can pass delimiter while creating a hive test table.