### PR TITLE
Fixes `HiveTable.writeExecution` bugs.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.12.0"
+version in ThisBuild := "2.12.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
It removes `MSCK REPAIR TABLE` statement since it is not needed. The
current use of it did not set the database and was broken.

It also changes the overwrite parts of the code to handle the case where
a table exists in the metastore but the underlying directory has been
deleted.

This fixes #426.