### PR TITLE
Removes unneeded dependency on scala-compiler

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -132,10 +132,7 @@ object build extends Build {
     ++ uniform.project("maestro-macros", "au.com.cba.omnia.maestro.macros")
     ++ Seq[Sett](
          libraryDependencies <++= scalaVersion.apply(sv => Seq(
-          "org.scala-lang"   % "scala-compiler" % sv
-            exclude("org.scala-lang.modules", "scala-parser-combinators_2.11")
-            exclude("org.scala-lang.modules", "scala-xml_2.11")
-         , "org.scala-lang"   % "scala-reflect"  % sv
+           "org.scala-lang" % "scala-reflect" % sv
          ) ++ depend.testing())
        , addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
     )

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.13.1"
+version in ThisBuild := "2.13.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Macros only require scala-reflect. Avoid listing scald-compiler as a dependency, since this will contribute an unnecessary transitive dependency to downstream projects.