### PR TITLE
Avoid race condition when creating unique names in parallel

### DIFF
--- a/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/hive/HiveTable.scala
+++ b/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/hive/HiveTable.scala
@@ -150,10 +150,10 @@ case class UnpartitionedHiveTable[A <: ThriftStruct : Manifest](
       def moveFiles(src: Path, dst: Path): Hdfs[Unit] = for {
         _     <- Hdfs.mkdirs(dst) // Create the folder if it doesn't already exist for some reason.
         files <- Hdfs.files(src, "*.parquet")
-        time  =  System.currentTimeMillis
+        uniq  =  UniqueID.getRandom.get
         _     <- Hdfs.mkdirs(dst)
         _     <- files.zipWithIndex.traverse {
-                   case (file, idx) => Hdfs.move(file, new Path(dst, f"part-$time-$idx%05d.parquet"))
+                   case (file, idx) => Hdfs.move(file, new Path(dst, f"part-$uniq-$idx%05d.parquet"))
                  }
       } yield ()
 

--- a/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/scalding/ConfHelper.scala
+++ b/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/scalding/ConfHelper.scala
@@ -16,7 +16,7 @@ package au.com.cba.omnia.maestro.scalding
 
 import org.apache.hadoop.mapred.JobConf
 
-import com.twitter.scalding.Config
+import com.twitter.scalding.{Config, UniqueID}
 
 /** Collection of utility methods around get/setting Config. */
 object ConfHelper {
@@ -33,6 +33,7 @@ object ConfHelper {
     *
     * This is used to get cascading to append to files to existing partitions.
     */
-  def createUniqueFilenames(config: Config): Config =
-    config + ("cascading.tapcollector.partname" -> s"%s%spart-${System.currentTimeMillis}-%05d-%05d")
+  def createUniqueFilenames(config: Config): Config = {
+    config + ("cascading.tapcollector.partname" -> s"%s%spart-${UniqueID.getRandom.get}-%05d-%05d")
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.14.1"
+version in ThisBuild := "2.14.2"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Use scalding's [`UniqueID`](https://github.com/twitter/scalding/blob/0.13.1/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala#L92) (which incorporates an atomic counter with the system time in millis) for more guaranteed unique part file names to avoid race condition that can arise when zipping executions that append to the same location.