### PR TITLE
Updating parlour version and test case for sqoop import

### DIFF
--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJob.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJob.scala
@@ -30,7 +30,7 @@ case class CustomerImportConfig(config: Config) {
     tablename     = "customer_import"
   )
   val sqoopImport  = maestro.sqoopImport(
-    initialOptions = Some(ParlourImportDsl().splitBy("id"))
+    initialOptions = Some(ParlourImportDsl().splitBy("id").hiveDropImportDelims)
   )
   val load        = maestro.load[Customer](
     none          = "null"

--- a/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJobSpec.scala
+++ b/maestro-example/src/test/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJobSpec.scala
@@ -75,11 +75,12 @@ Customer Sqoop Import Job test
   object CustomerImport {
     Class.forName("org.hsqldb.jdbcDriver")
 
+    // hiveDropImportDelims option removes the \n and \u0001
     val data = List(
-      "C001|Fred|0001|F|M|25",
+      "C001|Fred\n|0001|F|M|25",
       "C002|Barney|0002|S|M|2260",
       "C003|Home|0003|S|M|-10",
-      "C004|Wilma|0004|F|F|1003",
+      "C004|Wilma\u0001|0004|F|F|1003",
       "C005|Betty|0005|F|F|10000",
       "C006|Marge|0006|S|F|10"
     )

--- a/project/build.scala
+++ b/project/build.scala
@@ -40,7 +40,7 @@ object build extends Build {
   val permafrostVersion  = "0.10.0-20150729223234-1f86afc"
   val edgeVersion        = "3.4.0-20150513004502-4b6d30d"
   val humbugVersion      = "0.6.1-20150513010955-5eb6297"
-  val parlourVersion     = "1.9.0-20150724065522-8a0ce60"
+  val parlourVersion     = "1.10.0-20151105012616-a7fb575"
 
   val scalikejdbc = noHadoop("org.scalikejdbc" %% "scalikejdbc" % "2.2.6")
     .exclude("org.joda", "joda-convert")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.14.2"
+version in ThisBuild := "2.14.3"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Updating parlour version to support replace/removal of new line and control-A character from string columns during Sqoop import