### PR TITLE
Adds Fields typeclass and implicit instances

### DIFF
--- a/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Macros.scala
+++ b/maestro-macros/src/main/scala/au/com/cba/omnia/maestro/macros/Macros.scala
@@ -26,7 +26,7 @@ object Macros {
   def mkEncode[A <: ThriftStruct]: Encode[A] =
     macro EncodeMacro.impl[A]
 
-  def mkFields[A <: ThriftStruct]: Any =
+  def mkFields[A <: ThriftStruct]: FieldsMacro.Fields[A] =
     macro FieldsMacro.impl[A]
 
   def mkTag[A <: ThriftStruct]: Tag[A] =
@@ -92,9 +92,25 @@ trait MacroSupport {
   implicit def DerivedTag[A <: ThriftStruct]: Tag[A] =
     macro TagMacro.impl[A]
 
-  /** Macro generated structural type containing the fields for a Thrift struct. */
-  // NOTE: This isn't really any, it is a structural type containing all the fields.
-  def Fields[A <: ThriftStruct]: Any =
+  // type synonym so that "import Maestro.Fields" imports both type and def (below)
+  type Fields[A] = FieldsMacro.Fields[A]
+
+  /** Macro generated structural type containing the fields for a Thrift struct.
+    *
+    * Used with a concrete type, each field will be available as a property. Eg:
+    *
+    *     Fields[Customer].Balance
+    *
+    * If all you need is the [[AllFields]] member (i.e. a list of the fields), then
+    * you can instead obtain an implicit instance of the [[Fields]] typeclass.
+    * This has the benefit that it can be used in a generic context. Example:
+    *
+    *     def myGenericFunction[A : Fields] {
+    *       val fieldList = implicitly[Fields[A]].AllFields
+    *       // ...
+    *     }
+    */
+  implicit def Fields[A <: ThriftStruct]: Fields[A] =
     macro FieldsMacro.impl[A]
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.16.6"
+version in ThisBuild := "2.17.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
This is a proposal that will allow generic functions with `T <: ThriftStruct` to obtain a list of fields for `T`, in the same order that they would be written by `Encode`.

An example of how this is useful (and the motivating use case for this PR) is producing a header for a text file.

There are similarities with the existing `Tag` typeclass, but that is difficult to apply to the example above. In particular, it is impossible to use `Tag` without knowing at least the _number_ of fields.

I acknowledge that the name clash between the existing `Fields` macro and the new `Fields` typeclass is potentially confusing, but conceptually (albeit not technically) it is a generalisation of the existing interface, from being able to write:

    Fields[MyThrift].AllFields

to being able to extract the same code into a generic function by changing it to:

    implicitly[Fields[T]].AllFields