### PR TITLE
[Discussion] Run job with modified args

### DIFF
--- a/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/scalding/RichExecution.scala
+++ b/maestro-scalding/src/main/scala/au/com/cba/omnia/maestro/scalding/RichExecution.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 import scalaz.{\/, Monad}
 import scalaz.\&/.{These, This, That, Both}
 
-import com.twitter.scalding.{Config, Execution}
+import com.twitter.scalding.{Args, Config, Execution}
 
 import org.apache.hadoop.hive.conf.HiveConf
 
@@ -35,6 +35,11 @@ case class RichExecution[A](execution: Execution[A]) {
     Execution.getConfigMode.flatMap { case (config, mode) =>
       Execution.fromFuture(cec => execution.run(modifyConfig(config), mode)(cec))
     }
+
+  /** Modify args only */
+  def withSubArgs(modifyArgs: Args => Args): Execution[A] = {
+    withSubConfig(config => config.setArgs(modifyArgs(config.getArgs)))
+  }
 }
 
 /** Pimps the Execution object. */


### PR DESCRIPTION
Hi team, 

As we have handy `OminiaEnv` defined, and both [etl.util](https://github.com/CommBank/util.etl/blob/master/core/src/main/scala/au/com/cba/omnia/etl/util/SimpleMaestroJob.scala#L65) and coppersmith (https://github.com/CommBank/coppersmith/pull/175) should use it. I'm wondering:
1. If it's appropriate add `withSubArgs` function here.
2. Should we move some common things(e.g. `EtlConfiguration`, decode hive text table) to another internal library? Then both etl.util and coppersmith(or dataproducts.common) can benefit from it.

Thanks.