### PR TITLE
Fix byHour daylight savings transition and other time zone dependencies.

### DIFF
--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/partition/Partition.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/partition/Partition.scala
@@ -49,14 +49,14 @@ object Partition {
   /** Partition by year, month, day for a given dateFormat. */
   def byDate[A](date: Field[A, String], dateFormat: String = "y-M-d"): Partition[A, (String, String, String)] =
     Partition(List("year", "month", "day"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       (dt.getYear.toString, f"${dt.getMonthOfYear}%02d", f"${dt.getDayOfMonth}%02d")
     }, "%s/%s/%s")
 
   /** Partition by year, month, day, hour for a given dateFormat. */
   def byHour[A](date: Field[A, String], dateFormat: String = "y-M-d-H"): Partition[A, (String, String, String, String)] =
     Partition(List("year", "month", "day", "hour"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       (dt.getYear.toString, f"${dt.getMonthOfYear}%02d", f"${dt.getDayOfMonth}%02d", f"${dt.getHourOfDay}%02d")
     }, "%s/%s/%s/%s")
 
@@ -95,28 +95,28 @@ object HivePartition {
   /** Hive style partition by year for a given dateFormat. */
   def byYear[A](date: Field[A, String], dateFormat: String): Partition[A, String] =
     Partition(List("year"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       dt.getYear.toString
     }, "year=%s")
 
   /** Hive style partition by year, month for a given dateFormat. */
   def byMonth[A](date: Field[A, String], dateFormat: String): Partition[A, (String, String)] =
     Partition(List("year", "month"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       (dt.getYear.toString, f"${dt.getMonthOfYear}%02d")
     }, "year=%s/month=%s")
 
   /** Hive style partition by year, month, day for a given dateFormat. */
   def byDay[A](date: Field[A, String], dateFormat: String): Partition[A, (String, String, String)] =
     Partition(List("year", "month", "day"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       (dt.getYear.toString, f"${dt.getMonthOfYear}%02d", f"${dt.getDayOfMonth}%02d")
     }, "year=%s/month=%s/day=%s")
 
   /** Hive style partition by year, month, day, hour for a given dateFormat. */
   def byHour[A](date: Field[A, String], dateFormat: String): Partition[A, (String, String, String, String)] =
     Partition(List("year", "month", "day", "hour"), v => {
-      val dt = DateTimeFormat.forPattern(dateFormat).parseDateTime(date.get(v))
+      val dt = DateTimeFormat.forPattern(dateFormat).parseLocalDateTime(date.get(v))
       (dt.getYear.toString, f"${dt.getMonthOfYear}%02d", f"${dt.getDayOfMonth}%02d", f"${dt.getHourOfDay}%02d")
     }, "year=%s/month=%s/day=%s/hour=%s")
 }

--- a/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/time/TimeSource.scala
+++ b/maestro-core/src/main/scala/au/com/cba/omnia/maestro/core/time/TimeSource.scala
@@ -42,9 +42,15 @@ object TimeSource {
     predetermined(f.print(time))
   }
 
-  /** Use the current time as the time source */
-  def now(format: String = "yyyy-MM-dd"): TimeSource =
-    predetermined(new DateTime, format)
+  /** Use the current time as the time source, using a specified time zone. */
+  def now(format: String = "yyyy-MM-dd", tz: DateTimeZone): TimeSource =
+    predetermined(new DateTime(tz), format)
+
+  /** The current time in UTC. */
+  def nowUTC(format: String = "yyyy-MM-dd"): TimeSource = now(format, DateTimeZone.UTC)
+
+  /** The current time in Sydney. */
+  def nowSydney(format: String = "yyyy-MM-dd"): TimeSource = now(format, DateTimeZone.forID("Australia/Sydney"))
 
   /** Derive the load time from the file path */
   def fromPath(extract: String => String): TimeSource =

--- a/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/validate/CheckSpec.scala
+++ b/maestro-core/src/test/scala/au/com/cba/omnia/maestro/core/validate/CheckSpec.scala
@@ -17,7 +17,11 @@ package validate
 
 import org.scalacheck.{Arbitrary, Gen}
 
-import au.com.cba.omnia.omnitool.{Result, Ok}
+import scalaz._, \&/._
+
+import org.joda.time.format.DateTimeFormat
+
+import au.com.cba.omnia.omnitool.{Result, Ok, Error}
 
 import au.com.cba.omnia.maestro.core.test.Spec
 
@@ -26,10 +30,17 @@ object CheckSpec extends Spec { def is = s2"""
 Check properties
 ================
 
-  Check.oneOf                 $oneOf
-  Check.oneOf failure         $oneOfFailure
-  Check.nonempty              $nonempty
-  Check.nonempty failure      $nonemptyFailure
+  Check.oneOf                        $oneOf
+  Check.oneOf failure                $oneOfFailure
+  Check.formatIncludesTimeTrue       $formatIncludesTimeTrue
+  Check.formatIncludesTimeFalse      $formatIncludesTimeFalse
+  Check.isDateNoHour                 $isDateNoHour
+  Check.isDateNoTZ                   $isDateNoTZ
+  Check.isDateDaylightSavingsSkip    $isDateDaylightSavingsSkip
+  Check.isDateNoDaylightSavingsSkip  $isDateNoDaylightSavingsSkip
+  Check.isDateUTC                    $isDateUTC
+  Check.nonempty                     $nonempty
+  Check.nonempty failure             $nonemptyFailure
 
 """
   def categories = List("A", "B", "C", "D")
@@ -43,6 +54,28 @@ Check properties
       case Ok(_) => ko
       case _     => ok
     })
+
+  def formatIncludesTimeTrue =
+    Check.formatIncludesTime(DateTimeFormat.forPattern("y-M-d-H")) must_== true
+
+  def formatIncludesTimeFalse =
+    Check.formatIncludesTime(DateTimeFormat.forPattern("y-M-d")) must_== false
+
+  def isDateNoHour =
+    Check.isDate("y-M-d") must not(throwA[Exception])
+
+  def isDateNoTZ =
+    Check.isDate("y-M-d-H") must throwA[Exception]
+
+  def isDateDaylightSavingsSkip =
+    Check.isDateSydney("y-M-d-H-m").run("2016-10-02-02-30") must_==
+      Error(This("Date 2016-10-02-02-30 is not a valid date in the format y-M-d-H-m in Australia/Sydney"))
+
+  def isDateNoDaylightSavingsSkip =
+    Check.isDateSydney("y-M-d-H-m").run("2016-10-02-03-30") must_== Ok("2016-10-02-03-30")
+
+  def isDateUTC =        // The same date time string as the daylight savings skip in Sydney.
+    Check.isDateUTC("y-M-d-H-m").run("2016-10-02-02-30")  must_== Ok("2016-10-02-02-30")
 
   def nonempty = prop((s: String) => !s.isEmpty ==> {
     Check.nonempty.run(s) must_== Result.ok(s) })

--- a/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/LoadExecutionSpec.scala
+++ b/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/LoadExecutionSpec.scala
@@ -49,7 +49,7 @@ Load execution properties
 
 """
 
-  val conf = LoadConfig[StringPair](errors = "errors", timeSource = TimeSource.now(), none = "null")
+  val conf = LoadConfig[StringPair](errors = "errors", timeSource = TimeSource.nowUTC(), none = "null")
 
   def normal = {
     withEnvironment(path(getClass.getResource("/load-execution").toString)) {
@@ -99,7 +99,7 @@ Load execution properties
 
   def normalGenKey = {
     val confGenKey = LoadConfig[StringTriple](
-      errors = "errors", timeSource = TimeSource.now(), none = "null", generateKey = true
+      errors = "errors", timeSource = TimeSource.nowSydney(), none = "null", generateKey = true
     )
 
     withEnvironment(path(getClass.getResource("/load-execution").toString)) {
@@ -113,7 +113,7 @@ Load execution properties
 
   def tooLong = {
     val tripleConf = LoadConfig[StringTriple](
-      errors = "errors", timeSource = TimeSource.now(), none = "null"
+      errors = "errors", timeSource = TimeSource.nowUTC(), none = "null"
     )
 
     val data = List(
@@ -134,7 +134,7 @@ Load execution properties
 
   def tooShort = {
     val tripleConf = LoadConfig[StringTriple](
-      errors = "errors", timeSource = TimeSource.now(), none = "null"
+      errors = "errors", timeSource = TimeSource.nowUTC(), none = "null"
     )
 
     val data = List(

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.23.5"
+version in ThisBuild := "2.24.0"
 
 localVersionSettings
 


### PR DESCRIPTION
Addresses #497.

This includes some small API changes, just to force existing client code with unintended time zone dependencies to be revisited, similar to #483:

- `Check.isDate` now throws an exception if the pattern is time-sensitive and no time zone is specified.  Replace with `isDateUTC` or `isDateSydney` or explicitly give the intended time zone.

- `TimeSource.now` now requires an additional argument for the time zone.  For convenience, use `nowUTC` or `nowSydney`.