### PR TITLE
Support jobnotready and jobfailures wrapped in result exception during error recovery

### DIFF
--- a/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/scalding/MaestroExecutionSpec.scala
+++ b/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/scalding/MaestroExecutionSpec.scala
@@ -14,7 +14,13 @@
 
 package au.com.cba.omnia.maestro.scalding
 
+import com.twitter.scalding.Execution
+
+import au.com.cba.omnia.omnitool.Result
+
 import au.com.cba.omnia.thermometer.core.ThermometerSpec
+
+import ExecutionOps._
 
 object MaestroExecutionSpec extends ThermometerSpec { def is = s2"""
 
@@ -22,8 +28,10 @@ Maestro Execution functions
 ===========================
 
 Maestro Execution functions:
-  can recover `JobNotReadyError`  $jobNotReady
-  can recover `JobFailureError`   $jobFailure
+  can recover `JobNotReadyError`                             $jobNotReady
+  can recover `JobFailureError`                              $jobFailure
+  can recover `JobNotReadyError` wrapped in Result exception $jobNotReadyResultException
+  can recover `JobFailureError` wrapped in Result exception  $jobFailureResultException
 
 """
 
@@ -33,5 +41,15 @@ Maestro Execution functions:
 
   def jobFailure = {
     executesSuccessfully(MaestroExecution.recoverJobStatus(MaestroExecution.jobFailure(-2))) must_== JobFailure(-2)
+  }
+
+  def jobNotReadyResultException = {
+    val exec = Execution.fromResult(Result.safe(throw JobNotReadyException))
+    executesSuccessfully(MaestroExecution.recoverJobStatus(exec)) must_== JobNotReady
+  }
+
+  def jobFailureResultException = {
+    val exec = Execution.fromResult(Result.safe(throw JobFailureException(-2)))
+    executesSuccessfully(MaestroExecution.recoverJobStatus(exec)) must_== JobFailure(-2)
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.25.3"
+version in ThisBuild := "2.26.0"
 
 localVersionSettings
 


### PR DESCRIPTION
This is to Support `JobNotReadyException` and `JobFailureException` wrapped in `ResultException`  returning expected values during error recovery.