### PR TITLE
CDH 5.13.0

### DIFF
--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportJob.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopExportJob.scala
@@ -32,7 +32,7 @@ case class CustomerExportConfig(config: Config) {
   val upload    = maestro.upload()
   val load      = maestro.load[Customer](none = "null")
   val export     = maestro.sqoopExport[ParlourExportDsl](
-    dbTablename  = "customer_export"
+    dbTablename  = "CUSTOMER_EXPORT"
   )
 }
 

--- a/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJob.scala
+++ b/maestro-example/src/main/scala/au/com/cba/omnia/maestro/example/CustomerSqoopImportJob.scala
@@ -27,10 +27,10 @@ case class CustomerImportConfig(config: Config) {
     conf          = config,
     source        = "sales",
     domain        = "books",
-    tablename     = "customer_import"
+    tablename     = "CUSTOMER_IMPORT"
   )
   val sqoopImport  = maestro.sqoopImport(
-    initialOptions = Some(ParlourImportDsl().splitBy("id").hiveDropImportDelims)
+    initialOptions = Some(ParlourImportDsl().splitBy("ID").hiveDropImportDelims)
   )
   val load        = maestro.load[Customer](
     none          = "null"

--- a/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopExportExecutionSpec.scala
+++ b/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopExportExecutionSpec.scala
@@ -64,7 +64,7 @@ object SqoopExportExecutionSpec
   SqoopExecutionTest.setupEnv()
 
   def endToEndExportWithAppend = {
-    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     tableSetup(connectionString, username, password, table, Option(oldCustomers))
 
     withEnvironment(path(resourceUrl.toString)) {
@@ -75,7 +75,7 @@ object SqoopExportExecutionSpec
   }
 
   def endToEndExportPipe = {
-    val table = s"testobj_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"testobj_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     testObjTableSetup(connectionString, username, password, table)
 
     val config = SqoopExportConfig(options(table))
@@ -85,7 +85,7 @@ object SqoopExportExecutionSpec
   }
 
   def endToEndExportWithDeleteTest = {
-    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     tableSetup(connectionString, username, password, table, Option(oldCustomers))
 
     withEnvironment(path(resourceUrl.toString)) {
@@ -96,7 +96,7 @@ object SqoopExportExecutionSpec
   }
 
   def endToEndExportWithQuery = {
-    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     tableSetup(connectionString, username, password, table, Option(oldCustomers))
 
     withEnvironment(path(resourceUrl.toString)) {
@@ -115,7 +115,7 @@ object SqoopExportExecutionSpec
 
   def endToEndExportWithTeradataConnMan = {
     SqoopExecutionTest.setupEnv()
-    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     tableSetup(connectionString, username, password, table, Option(List()))
 
     withEnvironment(path(resourceUrl.toString)) {
@@ -126,7 +126,7 @@ object SqoopExportExecutionSpec
 
   def endToEndExportWithTeradataResetConnMan = {
     SqoopExecutionTest.setupEnv(customConnMan=Some(""))
-    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}"
+    val table = s"customer_export_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
     tableSetup(connectionString, username, password, table, Option(List()))
 
     withEnvironment(path(resourceUrl.toString)) {

--- a/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopImportExecutionSpec.scala
+++ b/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopImportExecutionSpec.scala
@@ -54,7 +54,7 @@ object SqoopImportExecutionSpec
   val password         = ""
   val hdfsRoot         = s"$dir/user/hdfs"
   val mapRedHome       = s"${System.getProperty("user.home")}/.ivy2/cache"
-  val importTableName  = s"customer_import_${UUID.randomUUID.toString.replace('-', '_')}"
+  val importTableName  = s"customer_import_${UUID.randomUUID.toString.replace('-', '_')}".toUpperCase
   val dirStructure     = s"sales/books/$importTableName"
   val hdfsLandingPath  = s"$hdfsRoot/source/$dirStructure"
   val hdfsArchivePath  = s"$hdfsRoot/archive/$dirStructure"

--- a/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopImportExecutionSpec.scala
+++ b/maestro-scalding/src/test/scala/au/com/cba/omnia/maestro/task/SqoopImportExecutionSpec.scala
@@ -62,7 +62,7 @@ object SqoopImportExecutionSpec
 
   val options = SqoopImportConfig.options[ParlourImportDsl](
     connectionString, username, password, importTableName
-  ).splitBy("id")
+  ).splitBy("ID")
 
   Class.forName("org.hsqldb.jdbcDriver")
 
@@ -83,8 +83,8 @@ object SqoopImportExecutionSpec
     val (path, count) = executesSuccessfully(sqoopImport(config))
     facts(
       ImportPathFact(path),
-      s"$hdfsLandingPath/$timePath" </> "part-m-00000"  ==> lines(data),
-      s"$hdfsArchivePath/$timePath" </> "part-00000.gz" ==> records(compressedRecordReader, data)
+      s"$hdfsLandingPath/$timePath" </> "part-m-*"  ==> lines(data),
+      s"$hdfsArchivePath/$timePath" </> "part-*.gz" ==> records(compressedRecordReader, data)
     )
     count must_== 3
   }
@@ -97,9 +97,9 @@ object SqoopImportExecutionSpec
     val (path, count) = executesSuccessfully(sqoopImport(config))
     facts(
       ImportPathFact(path),
-      s"$dir/user/hdfs/archive/sales/books" </> importTableName </> "2014/10/10" </> "part-00000.gz" ==>
+      s"$dir/user/hdfs/archive/sales/books" </> importTableName </> "2014/10/10" </> "part-*.gz" ==>
         records(compressedRecordReader, data),
-      s"$dir/user/hdfs/source/sales/books"  </> importTableName </> "2014/10/10" </> "part-m-00000"  ==>
+      s"$dir/user/hdfs/source/sales/books"  </> importTableName </> "2014/10/10" </> "part-m-*"  ==>
         lines(data)
     )
     count must_== 3
@@ -119,7 +119,7 @@ object SqoopImportExecutionSpec
 
   val teradataOptions = SqoopImportConfig.options[TeradataParlourImportDsl](
     connectionString, username, password, importTableName
-  ).splitBy("id")
+  ).splitBy("ID")
 
   def endToEndImportWithTeradataConnMan = {
     SqoopExecutionTest.setupEnv()
@@ -133,8 +133,8 @@ object SqoopImportExecutionSpec
     val (path, count) = executesSuccessfully(sqoopImport(config))
     facts(
       ImportPathFact(path),
-      s"$hdfsLandingPath/$timePath" </> "part-m-00000"  ==> lines(data),
-      s"$hdfsArchivePath/$timePath" </> "part-00000.gz" ==> records(compressedRecordReader, data)
+      s"$hdfsLandingPath/$timePath" </> "part-m-*"  ==> lines(data),
+      s"$hdfsArchivePath/$timePath" </> "part-*.gz" ==> records(compressedRecordReader, data)
     )
     count must_== 3
   }
@@ -171,8 +171,8 @@ object SqoopImportExecutionSpec
 
     executesSuccessfully(execution) must_==((3, 3))
     facts(
-      s"$hdfsLandingPath/$timePath"  </> "part-m-00000" ==> lines(data),
-      s"$hdfsLandingPath2/$timePath" </> "part-m-00000" ==> lines(data2)
+      s"$hdfsLandingPath/$timePath"  </> "part-m-*" ==> lines(data),
+      s"$hdfsLandingPath2/$timePath" </> "part-m-*" ==> lines(data2)
     )
   }
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -34,14 +34,14 @@ import au.com.cba.omnia.humbug.HumbugSBT._
 object build extends Build {
   type Sett = Def.Setting[_]
 
-  val thermometerVersion = "1.5.10-20170501023059-67accaf"
-  val ebenezerVersion    = "0.23.13-20170710073951-5e6af7a"
-  val beeswaxVersion     = "0.1.15-20170710010323-278c3d1"
-  val omnitoolVersion    = "1.14.9-20170710003444-8f25fcd"
-  val permafrostVersion  = "0.14.9-20170710010434-5ef0d52"
-  val edgeVersion        = "3.7.7-20170712132329-f484ec1"
-  val humbugVersion      = "0.7.8-20170501020334-64f8587"
-  val parlourVersion     = "1.12.15-20170501025705-cc9de5f"
+  val thermometerVersion = "1.6.0-20180124000127-aec09bd-cdh-513"
+  val ebenezerVersion    = "0.24.0-20180124043039-314e5ab-cdh-513"
+  val beeswaxVersion     = "0.2.0-20180124040559-79287a6-cdh-513"
+  val omnitoolVersion    = "1.15.0-20180124002420-8583973-cdh-513"
+  val permafrostVersion  = "0.15.0-20180124004456-0dff960-cdh-513"
+  val edgeVersion        = "3.8.0-20180124010647-d2b7fdc-cdh-513"
+  val humbugVersion      = "0.8.0-20180124005627-cf7d6c4-cdh-513"
+  val parlourVersion     = "1.13.0-20180124004451-69a7f45-cdh-513"
 
   val scalikejdbc = noHadoop("org.scalikejdbc" %% "scalikejdbc" % "2.2.6")
     .exclude("org.joda", "joda-convert")
@@ -104,7 +104,7 @@ object build extends Build {
            depend.scalaz()
         ++ depend.hadoopClasspath
         ++ depend.hadoop()
-        ++ depend.shapeless() ++ depend.testing() ++ depend.time()
+        ++ depend.shapeless() ++ depend.testing()
         ++ depend.omnia("beeswax",       beeswaxVersion)
         ++ depend.omnia("ebenezer",      ebenezerVersion)
         ++ depend.omnia("permafrost",    permafrostVersion)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers ++= Seq(
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
 )
 
-val uniformVersion = "1.15.1-20170426071414-6d891a6"
+val uniformVersion = "1.16.1-20180124040232-e0aaf4c-cdh-513"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
@@ -28,4 +28,4 @@ addSbtPlugin("au.com.cba.omnia" % "uniform-thrift"     % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
 
-addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.7.8-20170501020334-64f8587")
+addSbtPlugin("au.com.cba.omnia" % "humbug-plugin"      % "0.8.0-20180124005627-cf7d6c4-cdh-513")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "2.28.2"
+version in ThisBuild := "2.29.0"
 
 localVersionSettings
 


### PR DESCRIPTION
This will be merged into a new release branch: *cdh-513*. CDH 5.13.0 is not yet productionised in Omnia and won't be for a few months.

Driven by [Uniform PR #103](https://github.com/CommBank/uniform/pull/103) .

Upgrades libraries to CDH 5.13.0, as per:
 - https://archive.cloudera.com/cdh5/cdh/5/hadoop/hadoop-project-dist/hadoop-common/dependency-analysis.html
 - https://www.cloudera.com/documentation/enterprise/release-notes/topics/cm_vd_cdh_package_tarball_513.html